### PR TITLE
feat: POST /api/auth/register endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,18 @@
         "@prisma/adapter-pg": "^7.4.1",
         "@prisma/client": "^7.4.1",
         "@types/pg": "^8.16.0",
+        "bcryptjs": "^3.0.3",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "jsonwebtoken": "^9.0.3",
         "pg": "^8.18.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.3",
+        "@types/bcryptjs": "^2.4.6",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.3.0",
         "@types/supertest": "^6.0.3",
         "eslint": "^9.39.3",
@@ -1944,6 +1948,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -2056,10 +2067,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
       "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2802,6 +2831,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2921,6 +2959,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3615,6 +3659,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -5845,6 +5898,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5919,6 +6015,42 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5931,6 +6063,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -7239,6 +7377,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7257,7 +7415,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "type": "commonjs",
   "devDependencies": {
     "@eslint/js": "^9.39.3",
+    "@types/bcryptjs": "^2.4.6",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.3.0",
     "@types/supertest": "^6.0.3",
     "eslint": "^9.39.3",
@@ -42,8 +44,10 @@
     "@prisma/adapter-pg": "^7.4.1",
     "@prisma/client": "^7.4.1",
     "@types/pg": "^8.16.0",
+    "bcryptjs": "^3.0.3",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "jsonwebtoken": "^9.0.3",
     "pg": "^8.18.0"
   }
 }

--- a/src/__tests__/auth.register.integration.test.ts
+++ b/src/__tests__/auth.register.integration.test.ts
@@ -1,0 +1,99 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const BASE = '/api/auth/register';
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  // Clean up any users created during tests
+  await prisma.refreshToken.deleteMany({});
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@test.welltrack' } } });
+});
+
+describe('POST /api/auth/register', () => {
+  const validBody = {
+    email: 'alice@test.welltrack',
+    password: 'password123',
+    displayName: 'Alice',
+  };
+
+  it('returns 201 with user, accessToken, and refreshToken on success', async () => {
+    const res = await request(app).post(BASE).send(validBody);
+
+    expect(res.status).toBe(201);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.body.user).toMatchObject({
+      email: 'alice@test.welltrack',
+      displayName: 'Alice',
+    });
+    expect(typeof res.body.accessToken).toBe('string');
+    expect(typeof res.body.refreshToken).toBe('string');
+    expect(res.body.user.passwordHash).toBeUndefined();
+  });
+
+  it('stores the refresh token in the database', async () => {
+    const res = await request(app).post(BASE).send(validBody);
+
+    const stored = await prisma.refreshToken.findFirst({
+      where: { token: res.body.refreshToken },
+    });
+    expect(stored).not.toBeNull();
+    expect(stored?.userId).toBe(res.body.user.id);
+  });
+
+  it('normalises email to lowercase', async () => {
+    const res = await request(app)
+      .post(BASE)
+      .send({ ...validBody, email: 'Alice@Test.WellTrack' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.email).toBe('alice@test.welltrack');
+  });
+
+  it('works without displayName', async () => {
+    const res = await request(app)
+      .post(BASE)
+      .send({ email: 'bob@test.welltrack', password: 'password123' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.user.displayName).toBeNull();
+  });
+
+  it('returns 409 when email is already registered', async () => {
+    await request(app).post(BASE).send(validBody);
+    const res = await request(app).post(BASE).send(validBody);
+
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 422 for missing email', async () => {
+    const res = await request(app).post(BASE).send({ password: 'password123' });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for invalid email format', async () => {
+    const res = await request(app)
+      .post(BASE)
+      .send({ email: 'not-an-email', password: 'password123' });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for password shorter than 8 characters', async () => {
+    const res = await request(app)
+      .post(BASE)
+      .send({ email: 'carol@test.welltrack', password: 'short' });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for non-string displayName', async () => {
+    const res = await request(app)
+      .post(BASE)
+      .send({ email: 'dave@test.welltrack', password: 'password123', displayName: 42 });
+    expect(res.status).toBe(422);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import express from 'express';
+import authRouter from './routes/auth.router';
 
 const app = express();
 
@@ -8,5 +9,7 @@ app.use(express.json());
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
+
+app.use('/api/auth', authRouter);
 
 export default app;

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from 'express';
+import { register } from '../services/auth.service';
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export async function registerHandler(req: Request, res: Response): Promise<void> {
+  const { email, password, displayName } = req.body as Record<string, unknown>;
+
+  if (typeof email !== 'string' || !isValidEmail(email)) {
+    res.status(422).json({ error: 'A valid email address is required' });
+    return;
+  }
+  if (typeof password !== 'string' || password.length < 8) {
+    res.status(422).json({ error: 'Password must be at least 8 characters' });
+    return;
+  }
+  if (displayName !== undefined && typeof displayName !== 'string') {
+    res.status(422).json({ error: 'displayName must be a string' });
+    return;
+  }
+
+  try {
+    const result = await register({
+      email: email.toLowerCase().trim(),
+      password,
+      displayName: typeof displayName === 'string' ? displayName.trim() : undefined,
+    });
+    res.status(201).json(result);
+  } catch (err) {
+    const status = (err as Error & { status?: number }).status;
+    if (status === 409) {
+      res.status(409).json({ error: (err as Error).message });
+      return;
+    }
+    throw err;
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+const adapter = new PrismaPg({ connectionString: process.env['DATABASE_URL'] });
+
+const prisma = new PrismaClient({ adapter });
+
+export default prisma;

--- a/src/routes/auth.router.ts
+++ b/src/routes/auth.router.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { registerHandler } from '../controllers/auth.controller';
+
+const router = Router();
+
+router.post('/register', registerHandler);
+
+export default router;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,65 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import prisma from '../lib/prisma';
+
+const BCRYPT_ROUNDS = 12;
+const ACCESS_TOKEN_TTL = '15m';
+const REFRESH_TOKEN_TTL = '7d';
+const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function signAccessToken(userId: string, email: string): string {
+  const secret = process.env['JWT_SECRET'];
+  if (!secret) throw new Error('JWT_SECRET is not set');
+  return jwt.sign({ userId, email }, secret, { expiresIn: ACCESS_TOKEN_TTL });
+}
+
+function signRefreshToken(userId: string): string {
+  const secret = process.env['JWT_REFRESH_SECRET'];
+  if (!secret) throw new Error('JWT_REFRESH_SECRET is not set');
+  return jwt.sign({ userId }, secret, { expiresIn: REFRESH_TOKEN_TTL });
+}
+
+export interface RegisterInput {
+  email: string;
+  password: string;
+  displayName?: string;
+}
+
+export interface AuthResult {
+  user: { id: string; email: string; displayName: string | null };
+  accessToken: string;
+  refreshToken: string;
+}
+
+export async function register(input: RegisterInput): Promise<AuthResult> {
+  const existing = await prisma.user.findUnique({ where: { email: input.email } });
+  if (existing) {
+    const err = new Error('Email already in use');
+    (err as Error & { status: number }).status = 409;
+    throw err;
+  }
+
+  const passwordHash = await bcrypt.hash(input.password, BCRYPT_ROUNDS);
+
+  const user = await prisma.user.create({
+    data: {
+      email: input.email,
+      passwordHash,
+      displayName: input.displayName ?? null,
+    },
+    select: { id: true, email: true, displayName: true },
+  });
+
+  const accessToken = signAccessToken(user.id, user.email);
+  const refreshToken = signRefreshToken(user.id);
+
+  await prisma.refreshToken.create({
+    data: {
+      userId: user.id,
+      token: refreshToken,
+      expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
+    },
+  });
+
+  return { user, accessToken, refreshToken };
+}

--- a/tasks.md
+++ b/tasks.md
@@ -38,7 +38,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 
 ### Auth Endpoints
 
-- [ ] `POST /api/auth/register` — validate input, hash password with bcrypt (rounds = 12), create user, return JWT access token + refresh token
+- [x] `POST /api/auth/register` — validate input, hash password with bcrypt (rounds = 12), create user, return JWT access token + refresh token
 - [ ] `POST /api/auth/login` — verify email/password, return JWT access token + refresh token; store refresh token in DB
 - [ ] `POST /api/auth/refresh` — validate refresh token from DB, issue new access token (rotate refresh token)
 - [ ] `POST /api/auth/logout` — delete refresh token from DB


### PR DESCRIPTION
## Summary

- **`src/lib/prisma.ts`** — shared `PrismaClient` singleton (reuses the `PrismaPg` adapter pattern established in the seed script)
- **`src/services/auth.service.ts`** — `register()`: checks for duplicate email (409), hashes password with bcrypt (12 rounds), creates user, signs a 15-min JWT access token + 7-day refresh token, persists refresh token to `refresh_tokens` table
- **`src/controllers/auth.controller.ts`** — validates email format, password ≥ 8 chars, optional `displayName`; maps errors to 422/409; re-throws unexpected errors for a future error-handling middleware
- **`src/routes/auth.router.ts`** — `POST /register` → `registerHandler`
- **`src/app.ts`** — mounts auth router at `/api/auth`
- **`tasks.md`** — register task marked complete

## Response shape

```json
{
  "user": { "id": "...", "email": "alice@example.com", "displayName": "Alice" },
  "accessToken": "<15-min JWT>",
  "refreshToken": "<7-day JWT>"
}
```

## Test plan

9 integration tests in `src/__tests__/auth.register.integration.test.ts` — all passing (15/15 total across suite):

- [x] 201 with correct shape on success
- [x] Refresh token persisted to DB
- [x] Email normalised to lowercase
- [x] Works without `displayName`
- [x] 409 on duplicate email
- [x] 422 missing email
- [x] 422 invalid email format
- [x] 422 password < 8 chars
- [x] 422 non-string `displayName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)