### PR TITLE
feat: POST /api/auth/refresh endpoint with token rotation

### DIFF
--- a/src/__tests__/auth.refresh.integration.test.ts
+++ b/src/__tests__/auth.refresh.integration.test.ts
@@ -1,0 +1,105 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const REGISTER = '/api/auth/register';
+const REFRESH = '/api/auth/refresh';
+
+const testUser = {
+  email: 'refresh-test@refresh.welltrack',
+  password: 'password123',
+  displayName: 'Refresh Tester',
+};
+
+beforeAll(async () => {
+  // Deleting users cascades to refresh_tokens via FK
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@refresh.welltrack' } } });
+  await request(app).post(REGISTER).send(testUser);
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@refresh.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+async function getRefreshToken(): Promise<{ refreshToken: string; userId: string }> {
+  const res = await request(app).post(REGISTER).send({
+    email: `user-${Date.now()}@refresh.welltrack`,
+    password: 'password123',
+  });
+  return { refreshToken: res.body.refreshToken, userId: res.body.user.id };
+}
+
+describe('POST /api/auth/refresh', () => {
+  it('returns 200 with a new accessToken and refreshToken', async () => {
+    const { refreshToken } = await getRefreshToken();
+
+    const res = await request(app).post(REFRESH).send({ refreshToken });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(typeof res.body.accessToken).toBe('string');
+    expect(typeof res.body.refreshToken).toBe('string');
+  });
+
+  it('issues a different refreshToken each time (token rotation)', async () => {
+    const { refreshToken: original } = await getRefreshToken();
+
+    const res = await request(app).post(REFRESH).send({ refreshToken: original });
+
+    expect(res.body.refreshToken).not.toBe(original);
+  });
+
+  it('deletes the old refresh token from the database', async () => {
+    const { refreshToken: original } = await getRefreshToken();
+
+    await request(app).post(REFRESH).send({ refreshToken: original });
+
+    const stored = await prisma.refreshToken.findUnique({ where: { token: original } });
+    expect(stored).toBeNull();
+  });
+
+  it('stores the new refresh token in the database', async () => {
+    const { refreshToken: original } = await getRefreshToken();
+
+    const res = await request(app).post(REFRESH).send({ refreshToken: original });
+    const newToken = res.body.refreshToken;
+
+    const stored = await prisma.refreshToken.findUnique({ where: { token: newToken } });
+    expect(stored).not.toBeNull();
+  });
+
+  it('returns 401 when the old token is reused after rotation', async () => {
+    const { refreshToken: original } = await getRefreshToken();
+
+    await request(app).post(REFRESH).send({ refreshToken: original });
+
+    // Reuse the already-rotated token
+    const res = await request(app).post(REFRESH).send({ refreshToken: original });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a token with a valid signature but not in the DB', async () => {
+    // Get a token then wipe it directly from the DB
+    const { refreshToken, userId } = await getRefreshToken();
+    await prisma.refreshToken.deleteMany({ where: { userId } });
+
+    const res = await request(app).post(REFRESH).send({ refreshToken });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a completely invalid token string', async () => {
+    const res = await request(app).post(REFRESH).send({ refreshToken: 'not.a.jwt' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 422 when refreshToken is missing', async () => {
+    const res = await request(app).post(REFRESH).send({});
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 when refreshToken is not a string', async () => {
+    const res = await request(app).post(REFRESH).send({ refreshToken: 123 });
+    expect(res.status).toBe(422);
+  });
+});

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,8 +1,29 @@
 import { Request, Response } from 'express';
-import { login, register } from '../services/auth.service';
+import { login, refreshTokens, register } from '../services/auth.service';
 
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export async function refreshHandler(req: Request, res: Response): Promise<void> {
+  const { refreshToken } = req.body as Record<string, unknown>;
+
+  if (typeof refreshToken !== 'string' || refreshToken.trim().length === 0) {
+    res.status(422).json({ error: 'refreshToken is required' });
+    return;
+  }
+
+  try {
+    const result = await refreshTokens(refreshToken);
+    res.status(200).json(result);
+  } catch (err) {
+    const status = (err as Error & { status?: number }).status;
+    if (status === 401) {
+      res.status(401).json({ error: (err as Error).message });
+      return;
+    }
+    throw err;
+  }
 }
 
 export async function loginHandler(req: Request, res: Response): Promise<void> {

--- a/src/routes/auth.router.ts
+++ b/src/routes/auth.router.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
-import { loginHandler, registerHandler } from '../controllers/auth.controller';
+import { loginHandler, refreshHandler, registerHandler } from '../controllers/auth.controller';
 
 const router = Router();
 
 router.post('/register', registerHandler);
 router.post('/login', loginHandler);
+router.post('/refresh', refreshHandler);
 
 export default router;

--- a/tasks.md
+++ b/tasks.md
@@ -40,7 +40,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 
 - [x] `POST /api/auth/register` — validate input, hash password with bcrypt (rounds = 12), create user, return JWT access token + refresh token
 - [x] `POST /api/auth/login` — verify email/password, return JWT access token + refresh token; store refresh token in DB
-- [ ] `POST /api/auth/refresh` — validate refresh token from DB, issue new access token (rotate refresh token)
+- [x] `POST /api/auth/refresh` — validate refresh token from DB, issue new access token (rotate refresh token)
 - [ ] `POST /api/auth/logout` — delete refresh token from DB
 - [ ] `POST /api/auth/forgot-password` — generate a short-lived reset token, store hashed version in DB, send email with reset link (use Nodemailer or a stub for now)
 - [ ] `POST /api/auth/reset-password` — validate token, hash new password, update user, mark token as used


### PR DESCRIPTION
## Summary

- **`src/services/auth.service.ts`** — `refreshTokens()`: verifies JWT signature (401 on bad sig/expiry), looks up token in the `refresh_tokens` table (401 if not found or DB-expired), fetches the user, then atomically **rotates** — deletes the old token and creates a new one. Returns a fresh `accessToken` + `refreshToken`.
- **`src/controllers/auth.controller.ts`** — `refreshHandler`: validates `refreshToken` is a non-empty string (422), maps 401, re-throws unexpected errors
- **`src/routes/auth.router.ts`** — `POST /refresh → refreshHandler`

## Token rotation

Each call consumes the incoming refresh token and issues a brand new one. This means:
- A stolen token can only be used once before it's invalidated
- Reusing a rotated token immediately returns 401

## Response shape

```json
{
  "accessToken": "<new 15-min JWT>",
  "refreshToken": "<new 7-day JWT>"
}
```

## Test plan

9 integration tests in `src/__tests__/auth.refresh.integration.test.ts` — all 33 suite tests passing:

- [x] 200 with new accessToken and refreshToken
- [x] New refreshToken is different from the original
- [x] Old token deleted from DB after rotation
- [x] New token stored in DB
- [x] Reusing a rotated token returns 401
- [x] Valid-signature token not in DB returns 401
- [x] Completely invalid JWT string returns 401
- [x] Missing refreshToken field returns 422
- [x] Non-string refreshToken returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)