### PR TITLE
feat: POST /api/auth/logout

### DIFF
--- a/src/__tests__/auth.logout.integration.test.ts
+++ b/src/__tests__/auth.logout.integration.test.ts
@@ -1,0 +1,78 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const REGISTER = '/api/auth/register';
+const LOGIN = '/api/auth/login';
+const LOGOUT = '/api/auth/logout';
+
+const testUser = {
+  email: 'logout-me@logout.welltrack',
+  password: 'password123',
+  displayName: 'Logout Tester',
+};
+
+/** Register + login and return a fresh refreshToken. */
+async function getRefreshToken(): Promise<string> {
+  const res = await request(app)
+    .post(LOGIN)
+    .send({ email: testUser.email, password: testUser.password });
+  return res.body.refreshToken as string;
+}
+
+beforeAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@logout.welltrack' } } });
+  await request(app).post(REGISTER).send(testUser);
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@logout.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+describe('POST /api/auth/logout', () => {
+  it('returns 200 and a message on success', async () => {
+    const refreshToken = await getRefreshToken();
+    const res = await request(app).post(LOGOUT).send({ refreshToken });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('removes the refresh token from the database', async () => {
+    const refreshToken = await getRefreshToken();
+    await request(app).post(LOGOUT).send({ refreshToken });
+
+    const stored = await prisma.refreshToken.findUnique({ where: { token: refreshToken } });
+    expect(stored).toBeNull();
+  });
+
+  it('is idempotent — returns 200 even if the token is already gone', async () => {
+    const refreshToken = await getRefreshToken();
+    await request(app).post(LOGOUT).send({ refreshToken });
+    // Second logout with the same token
+    const res = await request(app).post(LOGOUT).send({ refreshToken });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('only removes the specified token, not all tokens for the user', async () => {
+    const token1 = await getRefreshToken();
+    const token2 = await getRefreshToken();
+
+    await request(app).post(LOGOUT).send({ refreshToken: token1 });
+
+    const remaining = await prisma.refreshToken.findUnique({ where: { token: token2 } });
+    expect(remaining).not.toBeNull();
+  });
+
+  it('returns 422 for missing refreshToken', async () => {
+    const res = await request(app).post(LOGOUT).send({});
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for empty refreshToken string', async () => {
+    const res = await request(app).post(LOGOUT).send({ refreshToken: '   ' });
+    expect(res.status).toBe(422);
+  });
+});

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,8 +1,20 @@
 import { Request, Response } from 'express';
-import { forgotPassword, login, refreshTokens, register } from '../services/auth.service';
+import { forgotPassword, login, logout, refreshTokens, register } from '../services/auth.service';
 
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export async function logoutHandler(req: Request, res: Response): Promise<void> {
+  const { refreshToken } = req.body as Record<string, unknown>;
+
+  if (typeof refreshToken !== 'string' || refreshToken.trim().length === 0) {
+    res.status(422).json({ error: 'refreshToken is required' });
+    return;
+  }
+
+  await logout(refreshToken);
+  res.status(200).json({ message: 'Logged out successfully' });
 }
 
 export async function forgotPasswordHandler(req: Request, res: Response): Promise<void> {

--- a/src/routes/auth.router.ts
+++ b/src/routes/auth.router.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
-import { forgotPasswordHandler, loginHandler, refreshHandler, registerHandler } from '../controllers/auth.controller';
+import { forgotPasswordHandler, loginHandler, logoutHandler, refreshHandler, registerHandler } from '../controllers/auth.controller';
 
 const router = Router();
 
 router.post('/register', registerHandler);
 router.post('/login', loginHandler);
 router.post('/refresh', refreshHandler);
+router.post('/logout', logoutHandler);
 router.post('/forgot-password', forgotPasswordHandler);
 
 export default router;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -133,6 +133,11 @@ export async function login(input: LoginInput): Promise<AuthResult> {
   };
 }
 
+export async function logout(refreshToken: string): Promise<void> {
+  // Silently ignore tokens that don't exist — logout is idempotent
+  await prisma.refreshToken.deleteMany({ where: { token: refreshToken } });
+}
+
 const RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 export interface ForgotPasswordInput {

--- a/tasks.md
+++ b/tasks.md
@@ -41,7 +41,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 - [x] `POST /api/auth/register` — validate input, hash password with bcrypt (rounds = 12), create user, return JWT access token + refresh token
 - [x] `POST /api/auth/login` — verify email/password, return JWT access token + refresh token; store refresh token in DB
 - [x] `POST /api/auth/refresh` — validate refresh token from DB, issue new access token (rotate refresh token)
-- [ ] `POST /api/auth/logout` — delete refresh token from DB
+- [x] `POST /api/auth/logout` — delete refresh token from DB
 - [x] `POST /api/auth/forgot-password` — generate a short-lived reset token, store hashed version in DB, send email with reset link (use Nodemailer or a stub for now)
 - [ ] `POST /api/auth/reset-password` — validate token, hash new password, update user, mark token as used
 - [ ] Create `authMiddleware` that verifies JWT and attaches `req.user` to the request


### PR DESCRIPTION
## Summary

- Adds `POST /api/auth/logout` endpoint
- Deletes the submitted `refreshToken` from the `refresh_tokens` table
- Idempotent — returns `200` even if the token doesn't exist (already expired or already logged out)
- Only removes the specific token provided; other active sessions for the same user are unaffected

## Test plan

- [x] `npm test` — passes on all existing + new tests
- [x] Returns 200 and removes token from DB
- [x] Second logout with same token still returns 200 (idempotent)
- [x] Only the specified token is deleted — other sessions remain
- [x] Returns 422 for missing or blank refreshToken

🤖 Generated with [Claude Code](https://claude.com/claude-code)