### PR TITLE
feat: authMiddleware — JWT verification

### DIFF
--- a/src/__tests__/auth.middleware.integration.test.ts
+++ b/src/__tests__/auth.middleware.integration.test.ts
@@ -1,0 +1,96 @@
+import express from 'express';
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+import { authMiddleware } from '../middleware/auth.middleware';
+
+const REGISTER = '/api/auth/register';
+const LOGIN = '/api/auth/login';
+
+// Minimal test app with one protected route
+const testApp = express();
+testApp.use(express.json());
+testApp.get('/protected', authMiddleware, (req, res) => {
+  res.status(200).json({ user: req.user });
+});
+
+const testUser = {
+  email: 'middleware@middleware.welltrack',
+  password: 'password123',
+};
+
+let accessToken: string;
+
+beforeAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@middleware.welltrack' } } });
+  await request(app).post(REGISTER).send(testUser);
+  const res = await request(app).post(LOGIN).send(testUser);
+  accessToken = res.body.accessToken as string;
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@middleware.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+describe('authMiddleware', () => {
+  it('calls next and attaches req.user for a valid token', async () => {
+    const res = await request(testApp)
+      .get('/protected')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.user).toHaveProperty('userId');
+    expect(res.body.user).toHaveProperty('email', testUser.email);
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await request(testApp).get('/protected');
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 401 when header does not start with Bearer', async () => {
+    const res = await request(testApp)
+      .get('/protected')
+      .set('Authorization', `Token ${accessToken}`);
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 401 for a malformed token', async () => {
+    const res = await request(testApp)
+      .get('/protected')
+      .set('Authorization', 'Bearer this.is.not.a.jwt');
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 401 for a token signed with the wrong secret', async () => {
+    const jwt = await import('jsonwebtoken');
+    const badToken = jwt.default.sign({ userId: 'fake', email: 'fake@test.com' }, 'wrong-secret');
+
+    const res = await request(testApp)
+      .get('/protected')
+      .set('Authorization', `Bearer ${badToken}`);
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 401 for an expired token', async () => {
+    const jwt = await import('jsonwebtoken');
+    const secret = process.env['JWT_SECRET']!;
+    // Sign with expiresIn of -1s (already expired)
+    const expiredToken = jwt.default.sign(
+      { userId: 'u1', email: 'x@x.com' },
+      secret,
+      { expiresIn: -1 },
+    );
+
+    const res = await request(testApp)
+      .get('/protected')
+      .set('Authorization', `Bearer ${expiredToken}`);
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+});

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+
+export function authMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing or invalid authorization header' });
+    return;
+  }
+
+  const token = authHeader.slice(7);
+  const secret = process.env['JWT_SECRET'];
+  if (!secret) throw new Error('JWT_SECRET is not set');
+
+  try {
+    const payload = jwt.verify(token, secret) as { userId: string; email: string };
+    req.user = { userId: payload.userId, email: payload.email };
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired access token' });
+  }
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,6 @@
+// Augment Express's Request type so req.user is available on protected routes.
+declare namespace Express {
+  interface Request {
+    user?: { userId: string; email: string };
+  }
+}

--- a/tasks.md
+++ b/tasks.md
@@ -44,7 +44,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 - [x] `POST /api/auth/logout` — delete refresh token from DB
 - [x] `POST /api/auth/forgot-password` — generate a short-lived reset token, store hashed version in DB, send email with reset link (use Nodemailer or a stub for now)
 - [x] `POST /api/auth/reset-password` — validate token, hash new password, update user, mark token as used
-- [ ] Create `authMiddleware` that verifies JWT and attaches `req.user` to the request
+- [x] Create `authMiddleware` that verifies JWT and attaches `req.user` to the request
 
 ### User Endpoints
 


### PR DESCRIPTION
## Summary

- Adds `src/middleware/auth.middleware.ts` — `authMiddleware` function for protecting routes
- Adds `src/types/express.d.ts` — augments `Express.Request` with `req.user?: { userId, email }` so protected handlers are fully type-safe

## How it works

1. Reads `Authorization: Bearer <token>` header — returns `401` if missing or wrong scheme
2. Calls `jwt.verify(token, JWT_SECRET)` — returns `401` for invalid signature or expiry
3. Attaches `req.user = { userId, email }` from the token payload and calls `next()`

## Usage on future protected routes

```ts
import { authMiddleware } from '../middleware/auth.middleware';

router.get('/me', authMiddleware, getMeHandler);
```

`req.user` is guaranteed to be populated inside any handler that follows `authMiddleware`.

## Test plan

- [x] `npm test` — 63/63 tests pass across 9 suites
- [x] Valid token → `req.user` attached, handler reached
- [x] Missing header → 401
- [x] Non-Bearer scheme → 401
- [x] Malformed token → 401
- [x] Wrong secret → 401
- [x] Expired token → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)