### PR TITLE
feat: GET /api/users/me

### DIFF
--- a/src/__tests__/users.get-me.integration.test.ts
+++ b/src/__tests__/users.get-me.integration.test.ts
@@ -1,0 +1,60 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const REGISTER = '/api/auth/register';
+const LOGIN = '/api/auth/login';
+const ME = '/api/users/me';
+
+const testUser = {
+  email: 'me@get-me.welltrack',
+  password: 'password123',
+  displayName: 'Get Me Tester',
+};
+
+let accessToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@get-me.welltrack' } } });
+  const reg = await request(app).post(REGISTER).send(testUser);
+  userId = reg.body.user.id as string;
+  const login = await request(app).post(LOGIN).send(testUser);
+  accessToken = login.body.accessToken as string;
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@get-me.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+describe('GET /api/users/me', () => {
+  it('returns 200 with the user profile for a valid token', async () => {
+    const res = await request(app).get(ME).set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.body).toMatchObject({
+      id: userId,
+      email: testUser.email,
+      displayName: testUser.displayName,
+      timezone: 'UTC',
+    });
+    expect(res.body).toHaveProperty('createdAt');
+  });
+
+  it('does not expose passwordHash', async () => {
+    const res = await request(app).get(ME).set('Authorization', `Bearer ${accessToken}`);
+    expect(res.body.passwordHash).toBeUndefined();
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).get(ME);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with a malformed token', async () => {
+    const res = await request(app).get(ME).set('Authorization', 'Bearer bad.token.here');
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import express from 'express';
 import authRouter from './routes/auth.router';
+import userRouter from './routes/user.router';
 
 const app = express();
 
@@ -11,5 +12,6 @@ app.get('/health', (_req, res) => {
 });
 
 app.use('/api/auth', authRouter);
+app.use('/api/users', userRouter);
 
 export default app;

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from 'express';
+import { getMe } from '../services/user.service';
+
+export async function getMeHandler(req: Request, res: Response): Promise<void> {
+  const user = await getMe(req.user!.userId);
+  res.status(200).json(user);
+}

--- a/src/routes/user.router.ts
+++ b/src/routes/user.router.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getMeHandler } from '../controllers/user.controller';
+import { authMiddleware } from '../middleware/auth.middleware';
+
+const router = Router();
+
+router.get('/me', authMiddleware, getMeHandler);
+
+export default router;

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,0 +1,24 @@
+import prisma from '../lib/prisma';
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  displayName: string | null;
+  timezone: string;
+  createdAt: Date;
+}
+
+export async function getMe(userId: string): Promise<UserProfile> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, displayName: true, timezone: true, createdAt: true },
+  });
+
+  if (!user) {
+    const err = new Error('User not found');
+    (err as Error & { status: number }).status = 404;
+    throw err;
+  }
+
+  return user;
+}

--- a/tasks.md
+++ b/tasks.md
@@ -48,7 +48,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 
 ### User Endpoints
 
-- [ ] `GET /api/users/me` — return the authenticated user's profile (exclude password_hash)
+- [x] `GET /api/users/me` — return the authenticated user's profile (exclude password_hash)
 - [ ] `PATCH /api/users/me` — allow updating `display_name` and `timezone`; validate timezone is a valid IANA string
 - [ ] `DELETE /api/users/me` — delete the user and cascade-delete all their data; invalidate tokens
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/users/me` — returns the authenticated user's profile
- Creates `src/services/user.service.ts`, `src/controllers/user.controller.ts`, `src/routes/user.router.ts`
- Mounts user router at `/api/users` in `app.ts`
- Protected by `authMiddleware`; `passwordHash` is never selected from the DB

## Test plan

- [x] Full suite passes
- [x] Returns id, email, displayName, timezone, createdAt
- [x] passwordHash absent from response
- [x] Returns 401 without / with bad token

🤖 Generated with [Claude Code](https://claude.com/claude-code)