### PR TITLE
feat: GET /api/symptom-logs

### DIFF
--- a/src/__tests__/symptom-logs.get.integration.test.ts
+++ b/src/__tests__/symptom-logs.get.integration.test.ts
@@ -1,0 +1,145 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const REGISTER = '/api/auth/register';
+const LOGIN = '/api/auth/login';
+const LOGS = '/api/symptom-logs';
+
+const testUser = { email: 'user@sym-logs-get.welltrack', password: 'password123' };
+
+let accessToken: string;
+let userId: string;
+let symptomId: string;
+
+beforeAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@sym-logs-get.welltrack' } } });
+
+  const reg = await request(app).post(REGISTER).send(testUser);
+  userId = reg.body.user.id as string;
+  const login = await request(app).post(LOGIN).send(testUser);
+  accessToken = login.body.accessToken as string;
+
+  // Create a symptom to log against
+  const sym = await prisma.symptom.create({ data: { userId, name: 'Test Headache' } });
+  symptomId = sym.id;
+
+  // Seed several logs at known times
+  const base = new Date('2025-01-10T12:00:00Z');
+  await prisma.symptomLog.createMany({
+    data: [
+      { userId, symptomId, severity: 7, loggedAt: new Date('2025-01-08T12:00:00Z') },
+      { userId, symptomId, severity: 5, notes: 'mild', loggedAt: new Date('2025-01-09T12:00:00Z') },
+      { userId, symptomId, severity: 9, loggedAt: base },
+      { userId, symptomId, severity: 3, loggedAt: new Date('2025-01-11T12:00:00Z') },
+    ],
+  });
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@sym-logs-get.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+describe('GET /api/symptom-logs', () => {
+  it('returns 200 with an array of the user\'s logs', async () => {
+    const res = await request(app).get(LOGS).set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('each log has the expected shape including nested symptom', async () => {
+    const res = await request(app).get(LOGS).set('Authorization', `Bearer ${accessToken}`);
+    const log = res.body[0];
+
+    expect(log).toHaveProperty('id');
+    expect(log).toHaveProperty('userId', userId);
+    expect(log).toHaveProperty('symptomId');
+    expect(log).toHaveProperty('severity');
+    expect(log).toHaveProperty('notes');
+    expect(log).toHaveProperty('loggedAt');
+    expect(log).toHaveProperty('createdAt');
+    expect(log.symptom).toMatchObject({ id: symptomId, name: 'Test Headache' });
+  });
+
+  it('results are ordered newest first', async () => {
+    const res = await request(app).get(LOGS).set('Authorization', `Bearer ${accessToken}`);
+    const dates = (res.body as { loggedAt: string }[]).map((l) => new Date(l.loggedAt).getTime());
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i - 1]).toBeGreaterThanOrEqual(dates[i]);
+    }
+  });
+
+  it('filters by startDate', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?startDate=2025-01-10T00:00:00Z`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    const dates = (res.body as { loggedAt: string }[]).map((l) => new Date(l.loggedAt));
+    dates.forEach((d) => expect(d.getTime()).toBeGreaterThanOrEqual(new Date('2025-01-10').getTime()));
+  });
+
+  it('filters by endDate', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?endDate=2025-01-09T23:59:59Z`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    const dates = (res.body as { loggedAt: string }[]).map((l) => new Date(l.loggedAt));
+    dates.forEach((d) => expect(d.getTime()).toBeLessThanOrEqual(new Date('2025-01-09T23:59:59Z').getTime()));
+  });
+
+  it('respects limit', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?limit=2`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('respects offset', async () => {
+    const allRes = await request(app).get(LOGS).set('Authorization', `Bearer ${accessToken}`);
+    const offsetRes = await request(app)
+      .get(`${LOGS}?limit=2&offset=1`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(offsetRes.body[0].id).toBe(allRes.body[1].id);
+  });
+
+  it("does not return another user's logs", async () => {
+    const otherReg = await request(app)
+      .post(REGISTER)
+      .send({ email: 'other@sym-logs-get.welltrack', password: 'password123' });
+    const otherId = otherReg.body.user.id as string;
+    await prisma.symptomLog.create({
+      data: { userId: otherId, symptomId, severity: 10 },
+    });
+
+    const res = await request(app).get(LOGS).set('Authorization', `Bearer ${accessToken}`);
+    const leaked = (res.body as { userId: string }[]).find((l) => l.userId === otherId);
+    expect(leaked).toBeUndefined();
+  });
+
+  it('returns 422 for an invalid startDate', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?startDate=notadate`)
+      .set('Authorization', `Bearer ${accessToken}`);
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for a negative limit', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?limit=-1`)
+      .set('Authorization', `Bearer ${accessToken}`);
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).get(LOGS);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import authRouter from './routes/auth.router';
 import userRouter from './routes/user.router';
 import symptomRouter from './routes/symptom.router';
+import symptomLogRouter from './routes/symptom-log.router';
 
 const app = express();
 
@@ -15,5 +16,6 @@ app.get('/health', (_req, res) => {
 app.use('/api/auth', authRouter);
 app.use('/api/users', userRouter);
 app.use('/api/symptoms', symptomRouter);
+app.use('/api/symptom-logs', symptomLogRouter);
 
 export default app;

--- a/src/controllers/symptom-log.controller.ts
+++ b/src/controllers/symptom-log.controller.ts
@@ -1,0 +1,55 @@
+import { Request, Response } from 'express';
+import { listSymptomLogs } from '../services/symptom-log.service';
+
+export async function listSymptomLogsHandler(req: Request, res: Response): Promise<void> {
+  const { startDate, endDate, limit, offset } = req.query as Record<string, string | undefined>;
+
+  // Parse and validate startDate
+  let parsedStart: Date | undefined;
+  if (startDate !== undefined) {
+    parsedStart = new Date(startDate);
+    if (isNaN(parsedStart.getTime())) {
+      res.status(422).json({ error: 'startDate must be a valid ISO 8601 date string' });
+      return;
+    }
+  }
+
+  // Parse and validate endDate
+  let parsedEnd: Date | undefined;
+  if (endDate !== undefined) {
+    parsedEnd = new Date(endDate);
+    if (isNaN(parsedEnd.getTime())) {
+      res.status(422).json({ error: 'endDate must be a valid ISO 8601 date string' });
+      return;
+    }
+  }
+
+  // Parse and validate limit
+  let parsedLimit: number | undefined;
+  if (limit !== undefined) {
+    parsedLimit = parseInt(limit, 10);
+    if (isNaN(parsedLimit) || parsedLimit < 1) {
+      res.status(422).json({ error: 'limit must be a positive integer' });
+      return;
+    }
+  }
+
+  // Parse and validate offset
+  let parsedOffset: number | undefined;
+  if (offset !== undefined) {
+    parsedOffset = parseInt(offset, 10);
+    if (isNaN(parsedOffset) || parsedOffset < 0) {
+      res.status(422).json({ error: 'offset must be a non-negative integer' });
+      return;
+    }
+  }
+
+  const logs = await listSymptomLogs(req.user!.userId, {
+    startDate: parsedStart,
+    endDate: parsedEnd,
+    limit: parsedLimit,
+    offset: parsedOffset,
+  });
+
+  res.status(200).json(logs);
+}

--- a/src/routes/symptom-log.router.ts
+++ b/src/routes/symptom-log.router.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { listSymptomLogsHandler } from '../controllers/symptom-log.controller';
+import { authMiddleware } from '../middleware/auth.middleware';
+
+const router = Router();
+
+router.get('/', authMiddleware, listSymptomLogsHandler);
+
+export default router;

--- a/src/services/symptom-log.service.ts
+++ b/src/services/symptom-log.service.ts
@@ -1,0 +1,57 @@
+import prisma from '../lib/prisma';
+
+export interface SymptomLogResult {
+  id: string;
+  userId: string;
+  symptomId: string;
+  severity: number;
+  notes: string | null;
+  loggedAt: Date;
+  createdAt: Date;
+  symptom: { id: string; name: string; category: string | null };
+}
+
+export interface ListSymptomLogsOptions {
+  startDate?: Date;
+  endDate?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export async function listSymptomLogs(
+  userId: string,
+  opts: ListSymptomLogsOptions = {},
+): Promise<SymptomLogResult[]> {
+  const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = opts.offset ?? 0;
+
+  return prisma.symptomLog.findMany({
+    where: {
+      userId,
+      ...(opts.startDate || opts.endDate
+        ? {
+            loggedAt: {
+              ...(opts.startDate && { gte: opts.startDate }),
+              ...(opts.endDate && { lte: opts.endDate }),
+            },
+          }
+        : {}),
+    },
+    select: {
+      id: true,
+      userId: true,
+      symptomId: true,
+      severity: true,
+      notes: true,
+      loggedAt: true,
+      createdAt: true,
+      symptom: { select: { id: true, name: true, category: true } },
+    },
+    orderBy: { loggedAt: 'desc' },
+    take: limit,
+    skip: offset,
+  });
+}

--- a/tasks.md
+++ b/tasks.md
@@ -61,7 +61,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 
 ### Symptom Logs CRUD
 
-- [ ] `GET /api/symptom-logs` — return logs filtered by optional `startDate`, `endDate`, `limit`, `offset` query params; only return the user's own logs
+- [x] `GET /api/symptom-logs` — return logs filtered by optional `startDate`, `endDate`, `limit`, `offset` query params; only return the user's own logs
 - [ ] `POST /api/symptom-logs` — create a symptom log entry; validate severity is 1–10
 - [ ] `PATCH /api/symptom-logs/:id` — update a log entry (must belong to current user)
 - [ ] `DELETE /api/symptom-logs/:id` — delete a log entry (must belong to current user)


### PR DESCRIPTION
## Summary

- Adds `GET /api/symptom-logs` with `startDate`, `endDate`, `limit`, `offset` query params
- Returns only the authenticated user's logs, ordered newest-first
- Each log includes a nested `symptom: { id, name, category }` to avoid extra round-trips
- Default limit 50, max 200

## Test plan

- [x] Full suite passes
- [x] Returns array with correct shape + nested symptom
- [x] Ordered newest first
- [x] Filters by startDate, endDate
- [x] Respects limit and offset
- [x] Does not leak another user's logs
- [x] 422 for invalid date / negative limit
- [x] 401 without token

🤖 Generated with [Claude Code](https://claude.com/claude-code)