### PR TITLE
feat: DELETE /api/symptom-logs/:id

### DIFF
--- a/src/__tests__/symptom-logs.delete.integration.test.ts
+++ b/src/__tests__/symptom-logs.delete.integration.test.ts
@@ -1,0 +1,98 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const REGISTER = '/api/auth/register';
+const LOGIN = '/api/auth/login';
+const LOGS = '/api/symptom-logs';
+
+const testUser = { email: 'user@sym-logs-delete.welltrack', password: 'password123' };
+
+let accessToken: string;
+let userId: string;
+let symptomId: string;
+let logId: string;
+
+beforeAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@sym-logs-delete.welltrack' } } });
+
+  const reg = await request(app).post(REGISTER).send(testUser);
+  userId = reg.body.user.id as string;
+  const login = await request(app).post(LOGIN).send(testUser);
+  accessToken = login.body.accessToken as string;
+
+  const sym = await prisma.symptom.create({ data: { userId, name: 'Delete Headache' } });
+  symptomId = sym.id;
+});
+
+beforeEach(async () => {
+  // Fresh log for each test
+  const log = await prisma.symptomLog.create({
+    data: { userId, symptomId, severity: 5, notes: 'to be deleted' },
+  });
+  logId = log.id;
+});
+
+afterEach(async () => {
+  await prisma.symptomLog.deleteMany({ where: { userId } });
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@sym-logs-delete.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+describe('DELETE /api/symptom-logs/:id', () => {
+  it('returns 204 and removes the log', async () => {
+    const res = await request(app)
+      .delete(`${LOGS}/${logId}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(204);
+    expect(res.body).toEqual({});
+
+    const gone = await prisma.symptomLog.findUnique({ where: { id: logId } });
+    expect(gone).toBeNull();
+  });
+
+  it('returns 404 on a second delete of the same id', async () => {
+    await request(app)
+      .delete(`${LOGS}/${logId}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    const res = await request(app)
+      .delete(`${LOGS}/${logId}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 for another user's log", async () => {
+    const otherReg = await request(app)
+      .post(REGISTER)
+      .send({ email: 'other@sym-logs-delete.welltrack', password: 'password123' });
+    const otherId = otherReg.body.user.id as string;
+    const otherLog = await prisma.symptomLog.create({
+      data: { userId: otherId, symptomId, severity: 3 },
+    });
+
+    const res = await request(app)
+      .delete(`${LOGS}/${otherLog.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for a non-existent id', async () => {
+    const res = await request(app)
+      .delete(`${LOGS}/nonexistentid`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).delete(`${LOGS}/${logId}`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/controllers/symptom-log.controller.ts
+++ b/src/controllers/symptom-log.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { createSymptomLog, listSymptomLogs, updateSymptomLog } from '../services/symptom-log.service';
+import { createSymptomLog, deleteSymptomLog, listSymptomLogs, updateSymptomLog } from '../services/symptom-log.service';
 
 export async function listSymptomLogsHandler(req: Request, res: Response): Promise<void> {
   const { startDate, endDate, limit, offset } = req.query as Record<string, string | undefined>;
@@ -91,6 +91,26 @@ export async function createSymptomLogHandler(req: Request, res: Response): Prom
     const status = (err as Error & { status?: number }).status;
     if (status === 404) {
       res.status(404).json({ error: (err as Error).message });
+      return;
+    }
+    throw err;
+  }
+}
+
+export async function deleteSymptomLogHandler(req: Request, res: Response): Promise<void> {
+  const id = req.params['id'] as string;
+
+  try {
+    await deleteSymptomLog(req.user!.userId, id);
+    res.status(204).send();
+  } catch (err) {
+    const status = (err as Error & { status?: number }).status;
+    if (status === 404) {
+      res.status(404).json({ error: (err as Error).message });
+      return;
+    }
+    if (status === 403) {
+      res.status(403).json({ error: (err as Error).message });
       return;
     }
     throw err;

--- a/src/routes/symptom-log.router.ts
+++ b/src/routes/symptom-log.router.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createSymptomLogHandler, listSymptomLogsHandler, updateSymptomLogHandler } from '../controllers/symptom-log.controller';
+import { createSymptomLogHandler, deleteSymptomLogHandler, listSymptomLogsHandler, updateSymptomLogHandler } from '../controllers/symptom-log.controller';
 import { authMiddleware } from '../middleware/auth.middleware';
 
 const router = Router();
@@ -7,5 +7,6 @@ const router = Router();
 router.get('/', authMiddleware, listSymptomLogsHandler);
 router.post('/', authMiddleware, createSymptomLogHandler);
 router.patch('/:id', authMiddleware, updateSymptomLogHandler);
+router.delete('/:id', authMiddleware, deleteSymptomLogHandler);
 
 export default router;

--- a/src/services/symptom-log.service.ts
+++ b/src/services/symptom-log.service.ts
@@ -106,6 +106,24 @@ export async function createSymptomLog(
   });
 }
 
+export async function deleteSymptomLog(userId: string, logId: string): Promise<void> {
+  const log = await prisma.symptomLog.findUnique({ where: { id: logId } });
+
+  if (!log) {
+    const err = new Error('Symptom log not found');
+    (err as Error & { status: number }).status = 404;
+    throw err;
+  }
+
+  if (log.userId !== userId) {
+    const err = new Error('Forbidden');
+    (err as Error & { status: number }).status = 403;
+    throw err;
+  }
+
+  await prisma.symptomLog.delete({ where: { id: logId } });
+}
+
 export async function listSymptomLogs(
   userId: string,
   opts: ListSymptomLogsOptions = {},

--- a/tasks.md
+++ b/tasks.md
@@ -64,7 +64,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 - [x] `GET /api/symptom-logs` — return logs filtered by optional `startDate`, `endDate`, `limit`, `offset` query params; only return the user's own logs
 - [x] `POST /api/symptom-logs` — create a symptom log entry; validate severity is 1–10
 - [x] `PATCH /api/symptom-logs/:id` — update a log entry (must belong to current user)
-- [ ] `DELETE /api/symptom-logs/:id` — delete a log entry (must belong to current user)
+- [x] `DELETE /api/symptom-logs/:id` — delete a log entry (must belong to current user)
 
 ### Mood Logs CRUD
 


### PR DESCRIPTION
## Summary
- Adds `deleteSymptomLog()` service function with 404/403 ownership guards
- Adds `deleteSymptomLogHandler` controller returning 204 No Content
- Registers `DELETE /:id` route in the symptom-log router

## Testing Notes
- 5 integration tests: 204 happy path + DB deletion verified, 404 on re-delete, 403 for another user's log, 404 for non-existent id, 401 without token
- All 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)