### PR TITLE
feat: GET /api/mood-logs

### DIFF
--- a/src/__tests__/mood-logs.get.integration.test.ts
+++ b/src/__tests__/mood-logs.get.integration.test.ts
@@ -1,0 +1,145 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const REGISTER = '/api/auth/register';
+const LOGIN = '/api/auth/login';
+const LOGS = '/api/mood-logs';
+
+const testUser = { email: 'user@mood-logs-get.welltrack', password: 'password123' };
+
+let accessToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@mood-logs-get.welltrack' } } });
+
+  const reg = await request(app).post(REGISTER).send(testUser);
+  userId = reg.body.user.id as string;
+  const login = await request(app).post(LOGIN).send(testUser);
+  accessToken = login.body.accessToken as string;
+
+  // Insert 4 logs at known timestamps
+  await prisma.moodLog.createMany({
+    data: [
+      { userId, moodScore: 3, loggedAt: new Date('2025-01-08T10:00:00Z') },
+      { userId, moodScore: 4, energyLevel: 3, loggedAt: new Date('2025-01-09T10:00:00Z') },
+      { userId, moodScore: 5, stressLevel: 2, loggedAt: new Date('2025-01-10T10:00:00Z') },
+      { userId, moodScore: 2, notes: 'rough day', loggedAt: new Date('2025-01-11T10:00:00Z') },
+    ],
+  });
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@mood-logs-get.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+describe('GET /api/mood-logs', () => {
+  it('returns 200 with an array', async () => {
+    const res = await request(app)
+      .get(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(4);
+  });
+
+  it('each log has the expected shape', async () => {
+    const res = await request(app)
+      .get(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    const log = res.body[0];
+    expect(log).toHaveProperty('id');
+    expect(log).toHaveProperty('userId');
+    expect(log).toHaveProperty('moodScore');
+    expect(log).toHaveProperty('energyLevel');
+    expect(log).toHaveProperty('stressLevel');
+    expect(log).toHaveProperty('notes');
+    expect(log).toHaveProperty('loggedAt');
+    expect(log).toHaveProperty('createdAt');
+  });
+
+  it('returns logs newest-first', async () => {
+    const res = await request(app)
+      .get(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    const dates = res.body.map((l: { loggedAt: string }) => new Date(l.loggedAt).getTime());
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i - 1]).toBeGreaterThanOrEqual(dates[i]);
+    }
+  });
+
+  it('filters by startDate', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?startDate=2025-01-10T00:00:00Z`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(2);
+  });
+
+  it('filters by endDate', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?endDate=2025-01-09T23:59:59Z`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(2);
+  });
+
+  it('respects limit', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?limit=2`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(2);
+  });
+
+  it('respects offset', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?offset=3`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+  });
+
+  it('does not return another user\'s logs', async () => {
+    const otherReg = await request(app)
+      .post(REGISTER)
+      .send({ email: 'other@mood-logs-get.welltrack', password: 'password123' });
+    const otherId = otherReg.body.user.id as string;
+    await prisma.moodLog.create({ data: { userId: otherId, moodScore: 1 } });
+
+    const res = await request(app)
+      .get(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    const ids = res.body.map((l: { userId: string }) => l.userId);
+    expect(ids.every((id: string) => id === userId)).toBe(true);
+  });
+
+  it('returns 422 for invalid startDate', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?startDate=notadate`)
+      .set('Authorization', `Bearer ${accessToken}`);
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for negative limit', async () => {
+    const res = await request(app)
+      .get(`${LOGS}?limit=-1`)
+      .set('Authorization', `Bearer ${accessToken}`);
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).get(LOGS);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import authRouter from './routes/auth.router';
 import userRouter from './routes/user.router';
 import symptomRouter from './routes/symptom.router';
 import symptomLogRouter from './routes/symptom-log.router';
+import moodLogRouter from './routes/mood-log.router';
 
 const app = express();
 
@@ -17,5 +18,6 @@ app.use('/api/auth', authRouter);
 app.use('/api/users', userRouter);
 app.use('/api/symptoms', symptomRouter);
 app.use('/api/symptom-logs', symptomLogRouter);
+app.use('/api/mood-logs', moodLogRouter);
 
 export default app;

--- a/src/controllers/mood-log.controller.ts
+++ b/src/controllers/mood-log.controller.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express';
+import { listMoodLogs } from '../services/mood-log.service';
+
+export async function listMoodLogsHandler(req: Request, res: Response): Promise<void> {
+  const { startDate, endDate, limit, offset } = req.query as Record<string, string | undefined>;
+
+  let parsedStart: Date | undefined;
+  if (startDate !== undefined) {
+    parsedStart = new Date(startDate);
+    if (isNaN(parsedStart.getTime())) {
+      res.status(422).json({ error: 'startDate must be a valid ISO 8601 date string' });
+      return;
+    }
+  }
+
+  let parsedEnd: Date | undefined;
+  if (endDate !== undefined) {
+    parsedEnd = new Date(endDate);
+    if (isNaN(parsedEnd.getTime())) {
+      res.status(422).json({ error: 'endDate must be a valid ISO 8601 date string' });
+      return;
+    }
+  }
+
+  let parsedLimit: number | undefined;
+  if (limit !== undefined) {
+    parsedLimit = parseInt(limit, 10);
+    if (isNaN(parsedLimit) || parsedLimit < 1) {
+      res.status(422).json({ error: 'limit must be a positive integer' });
+      return;
+    }
+  }
+
+  let parsedOffset: number | undefined;
+  if (offset !== undefined) {
+    parsedOffset = parseInt(offset, 10);
+    if (isNaN(parsedOffset) || parsedOffset < 0) {
+      res.status(422).json({ error: 'offset must be a non-negative integer' });
+      return;
+    }
+  }
+
+  const logs = await listMoodLogs(req.user!.userId, {
+    startDate: parsedStart,
+    endDate: parsedEnd,
+    limit: parsedLimit,
+    offset: parsedOffset,
+  });
+
+  res.status(200).json(logs);
+}

--- a/src/routes/mood-log.router.ts
+++ b/src/routes/mood-log.router.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { listMoodLogsHandler } from '../controllers/mood-log.controller';
+import { authMiddleware } from '../middleware/auth.middleware';
+
+const router = Router();
+
+router.get('/', authMiddleware, listMoodLogsHandler);
+
+export default router;

--- a/src/services/mood-log.service.ts
+++ b/src/services/mood-log.service.ts
@@ -1,0 +1,57 @@
+import prisma from '../lib/prisma';
+
+export interface MoodLogResult {
+  id: string;
+  userId: string;
+  moodScore: number;
+  energyLevel: number | null;
+  stressLevel: number | null;
+  notes: string | null;
+  loggedAt: Date;
+  createdAt: Date;
+}
+
+export interface ListMoodLogsOptions {
+  startDate?: Date;
+  endDate?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export async function listMoodLogs(
+  userId: string,
+  opts: ListMoodLogsOptions = {},
+): Promise<MoodLogResult[]> {
+  const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = opts.offset ?? 0;
+
+  return prisma.moodLog.findMany({
+    where: {
+      userId,
+      ...(opts.startDate || opts.endDate
+        ? {
+            loggedAt: {
+              ...(opts.startDate && { gte: opts.startDate }),
+              ...(opts.endDate && { lte: opts.endDate }),
+            },
+          }
+        : {}),
+    },
+    select: {
+      id: true,
+      userId: true,
+      moodScore: true,
+      energyLevel: true,
+      stressLevel: true,
+      notes: true,
+      loggedAt: true,
+      createdAt: true,
+    },
+    orderBy: { loggedAt: 'desc' },
+    take: limit,
+    skip: offset,
+  });
+}

--- a/tasks.md
+++ b/tasks.md
@@ -68,7 +68,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 
 ### Mood Logs CRUD
 
-- [ ] `GET /api/mood-logs` — return mood logs with optional `startDate` / `endDate` filters
+- [x] `GET /api/mood-logs` — return mood logs with optional `startDate` / `endDate` filters
 - [ ] `POST /api/mood-logs` — create a mood log; validate mood_score (1–5), energy_level (1–5), stress_level (1–5)
 - [ ] `PATCH /api/mood-logs/:id` — update a mood log entry
 - [ ] `DELETE /api/mood-logs/:id` — delete a mood log entry


### PR DESCRIPTION
## Summary
- Creates `src/services/mood-log.service.ts` with `listMoodLogs()`
- Creates `src/controllers/mood-log.controller.ts` with `listMoodLogsHandler`
- Creates `src/routes/mood-log.router.ts` and mounts at `/api/mood-logs` in `app.ts`
- Supports `startDate`, `endDate`, `limit` (default 50, max 200), `offset` query params

## Test plan
- 11 integration tests: array shape, field presence, newest-first ordering, date filters, limit/offset, no data leak, 422 validations, 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)