### PR TITLE
feat: POST /api/mood-logs

### DIFF
--- a/src/__tests__/mood-logs.post.integration.test.ts
+++ b/src/__tests__/mood-logs.post.integration.test.ts
@@ -1,0 +1,126 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const REGISTER = '/api/auth/register';
+const LOGIN = '/api/auth/login';
+const LOGS = '/api/mood-logs';
+
+const testUser = { email: 'user@mood-logs-post.welltrack', password: 'password123' };
+
+let accessToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@mood-logs-post.welltrack' } } });
+  const reg = await request(app).post(REGISTER).send(testUser);
+  userId = reg.body.user.id as string;
+  const login = await request(app).post(LOGIN).send(testUser);
+  accessToken = login.body.accessToken as string;
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@mood-logs-post.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+describe('POST /api/mood-logs', () => {
+  it('returns 201 with required fields only', async () => {
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ moodScore: 3 });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ userId, moodScore: 3, energyLevel: null, stressLevel: null, notes: null });
+    expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('loggedAt');
+  });
+
+  it('returns 201 with all optional fields', async () => {
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ moodScore: 4, energyLevel: 3, stressLevel: 2, notes: 'feeling ok' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ moodScore: 4, energyLevel: 3, stressLevel: 2, notes: 'feeling ok' });
+  });
+
+  it('uses current time when loggedAt is omitted', async () => {
+    const before = Date.now();
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ moodScore: 2 });
+    const after = Date.now();
+
+    const loggedAt = new Date(res.body.loggedAt).getTime();
+    expect(loggedAt).toBeGreaterThanOrEqual(before);
+    expect(loggedAt).toBeLessThanOrEqual(after);
+  });
+
+  it('accepts a custom loggedAt for backfilling', async () => {
+    const pastDate = '2024-06-15T10:00:00Z';
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ moodScore: 5, loggedAt: pastDate });
+
+    expect(res.status).toBe(201);
+    expect(new Date(res.body.loggedAt).toISOString()).toBe(new Date(pastDate).toISOString());
+  });
+
+  it('returns 422 for missing moodScore', async () => {
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ energyLevel: 3 });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for moodScore out of range (0)', async () => {
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ moodScore: 0 });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for moodScore out of range (6)', async () => {
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ moodScore: 6 });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for energyLevel out of range', async () => {
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ moodScore: 3, energyLevel: 6 });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for stressLevel out of range', async () => {
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ moodScore: 3, stressLevel: 0 });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 422 for invalid loggedAt', async () => {
+    const res = await request(app)
+      .post(LOGS)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ moodScore: 3, loggedAt: 'not-a-date' });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).post(LOGS).send({ moodScore: 3 });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/routes/mood-log.router.ts
+++ b/src/routes/mood-log.router.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
-import { listMoodLogsHandler } from '../controllers/mood-log.controller';
+import { createMoodLogHandler, listMoodLogsHandler } from '../controllers/mood-log.controller';
 import { authMiddleware } from '../middleware/auth.middleware';
 
 const router = Router();
 
 router.get('/', authMiddleware, listMoodLogsHandler);
+router.post('/', authMiddleware, createMoodLogHandler);
 
 export default router;

--- a/src/services/mood-log.service.ts
+++ b/src/services/mood-log.service.ts
@@ -21,6 +21,40 @@ export interface ListMoodLogsOptions {
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
 
+export interface CreateMoodLogInput {
+  moodScore: number;
+  energyLevel?: number;
+  stressLevel?: number;
+  notes?: string;
+  loggedAt?: Date;
+}
+
+export async function createMoodLog(
+  userId: string,
+  input: CreateMoodLogInput,
+): Promise<MoodLogResult> {
+  return prisma.moodLog.create({
+    data: {
+      userId,
+      moodScore: input.moodScore,
+      energyLevel: input.energyLevel ?? null,
+      stressLevel: input.stressLevel ?? null,
+      notes: input.notes ?? null,
+      loggedAt: input.loggedAt ?? new Date(),
+    },
+    select: {
+      id: true,
+      userId: true,
+      moodScore: true,
+      energyLevel: true,
+      stressLevel: true,
+      notes: true,
+      loggedAt: true,
+      createdAt: true,
+    },
+  });
+}
+
 export async function listMoodLogs(
   userId: string,
   opts: ListMoodLogsOptions = {},

--- a/tasks.md
+++ b/tasks.md
@@ -69,7 +69,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 ### Mood Logs CRUD
 
 - [x] `GET /api/mood-logs` — return mood logs with optional `startDate` / `endDate` filters
-- [ ] `POST /api/mood-logs` — create a mood log; validate mood_score (1–5), energy_level (1–5), stress_level (1–5)
+- [x] `POST /api/mood-logs` — create a mood log; validate mood_score (1–5), energy_level (1–5), stress_level (1–5)
 - [ ] `PATCH /api/mood-logs/:id` — update a mood log entry
 - [ ] `DELETE /api/mood-logs/:id` — delete a mood log entry
 


### PR DESCRIPTION
## Summary
- Adds `createMoodLog()` to mood-log service
- Adds `createMoodLogHandler` to mood-log controller
- Registers `POST /` route in mood-log router

## Test plan
- 11 integration tests: 201 with required/all fields, default/custom loggedAt, 422 for invalid scores and date, 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)