### PR TITLE
docs: expand architecture notes and add Documentation section for Phase 2 completion

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,6 +56,39 @@ npm start         # Run compiled output (production mode)
 
 ---
 
+## Running the Frontend
+
+The frontend lives in `client/` and is a **separate npm project** with its own `package.json`.
+
+```bash
+# First time
+cd client && npm install
+
+# Start the Vite dev server
+cd client && npm run dev
+# → http://localhost:5173
+```
+
+Vite proxies all `/api` requests to `http://localhost:3000`, so the API server must be running at the same time.
+
+**Run both together (two terminals):**
+
+```bash
+# Terminal 1 — API
+npm run dev
+
+# Terminal 2 — Frontend
+cd client && npm run dev
+```
+
+**Build for production:**
+
+```bash
+cd client && npm run build   # Outputs to client/dist/
+```
+
+---
+
 ## Tests
 
 The test suite requires the database to be running.
@@ -112,5 +145,6 @@ npx prisma studio            # Open Prisma Studio GUI at localhost:5555
 | `DATABASE_URL` | PostgreSQL connection string | `postgresql://welltrack:welltrack@localhost:5432/welltrack` |
 | `JWT_SECRET` | Signs access tokens (15-min) | *(set in .env)* |
 | `JWT_REFRESH_SECRET` | Signs refresh tokens (7-day) | *(set in .env)* |
+| `CLIENT_ORIGIN` | CORS allowed origin for the frontend | `http://localhost:5173` |
 
 Never commit `.env`. It is git-ignored.


### PR DESCRIPTION
## Summary

End-of-phase documentation pass covering everything built in Phase 2.

### CLAUDE.md
- **Frontend folder structure table** — maps every `client/src/` path to its purpose
- **Route map** — all 8 routes (public + protected) with notes on stubs
- **Auth token handling** — access token in-memory, refresh token in localStorage, on-failure behaviour
- **Frontend patterns** — API calls, error display, loading states, form submit, modal pattern, color palette
- **Dashboard data fetching note** — explains the single `Promise.all` / date-prefix filtering approach and `createdAt` vs `loggedAt` distinction for medication logs
- **Documentation section** — table of what each `.md` file is for, when to update it, and rules for keeping docs current

### DEVELOPMENT.md
- **Running the Frontend** section — `npm install`, dev server at `:5173`, two-terminal workflow, production build
- **`CLIENT_ORIGIN`** added to the environment variables table (was missing)

## Why
Stale CLAUDE.md = bad AI suggestions next session. These updates capture the patterns we've established so the next phase starts with accurate context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)