### PR TITLE
feat: add shared Modal component (task 55)

### DIFF
--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -1,0 +1,34 @@
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function Modal({ isOpen, onClose, title, children }: ModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-xl bg-white shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+          <h2 className="text-lg font-semibold text-gray-800">{title}</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="max-h-[80vh] overflow-y-auto px-6 py-5">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/tasks.md
+++ b/tasks.md
@@ -144,7 +144,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 
 ### Logging Forms / Modals
 
-- [ ] Build a shared `Modal` component that can wrap any content
+- [x] Build a shared `Modal` component that can wrap any content
 - [ ] Build `LogSymptomModal`: dropdown to select symptom, 1–10 severity slider or number input, optional notes, date/time picker (defaults to now)
 - [ ] Build `LogMoodModal`: 1–5 rating for mood, optional energy and stress ratings, optional notes, date/time picker
 - [ ] Build `LogMedicationModal`: select medication from list, toggle taken/not taken, optional taken_at time, notes


### PR DESCRIPTION
## Summary
- Adds `client/src/components/Modal.tsx` — a reusable overlay modal that accepts `isOpen`, `onClose`, `title`, and `children`
- Backdrop click closes the modal; inner click is stopped from propagating
- Scrollable content area capped at 80 vh for tall forms

## Test plan
- [ ] Import Modal in any page, pass `isOpen={true}`, confirm overlay and title render
- [ ] Click backdrop → modal closes; click inside modal → stays open
- [ ] Content taller than viewport scrolls within the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)