### PR TITLE
feat: extend log modals with edit/PATCH support (task 61)

### DIFF
--- a/client/src/components/LogMedicationModal.tsx
+++ b/client/src/components/LogMedicationModal.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 import Modal from './Modal';
 import api from '../services/api';
-import type { ApiError, Medication } from '../types/api';
+import type { ApiError, Medication, MedicationLog } from '../types/api';
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   onSuccess: () => void;
+  log?: MedicationLog; // when provided: edit mode (pre-fill + PATCH)
 }
 
 function toLocalDateTimeString(date: Date): string {
@@ -15,7 +16,7 @@ function toLocalDateTimeString(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
-export default function LogMedicationModal({ isOpen, onClose, onSuccess }: Props) {
+export default function LogMedicationModal({ isOpen, onClose, onSuccess, log }: Props) {
   const [medications, setMedications] = useState<Medication[]>([]);
   const [medicationId, setMedicationId] = useState('');
   const [taken, setTaken] = useState(true);
@@ -25,38 +26,62 @@ export default function LogMedicationModal({ isOpen, onClose, onSuccess }: Props
   const [error, setError] = useState<string | null>(null);
   const [loadingMeds, setLoadingMeds] = useState(false);
 
+  // Fetch medication list when modal opens
   useEffect(() => {
     if (!isOpen) return;
-    setError(null);
     setLoadingMeds(true);
     api
       .get<Medication[]>('/api/medications')
       .then((res) => {
         const active = res.data.filter((m) => m.isActive);
         setMedications(active);
-        if (active.length > 0 && !medicationId) {
-          setMedicationId(active[0]!.id);
+        // In create mode, default to the first active medication
+        if (!log && active.length > 0) {
+          setMedicationId((prev) => prev || active[0]!.id);
         }
       })
       .finally(() => setLoadingMeds(false));
-  }, [isOpen]);
+  }, [isOpen, log]);
+
+  // Pre-fill form fields when opening
+  useEffect(() => {
+    if (!isOpen) return;
+    setError(null);
+    if (log) {
+      setMedicationId(log.medicationId);
+      setTaken(log.taken);
+      setTakenAt(
+        log.takenAt
+          ? toLocalDateTimeString(new Date(log.takenAt))
+          : toLocalDateTimeString(new Date()),
+      );
+      setNotes(log.notes ?? '');
+    } else {
+      setMedicationId('');
+      setTaken(true);
+      setTakenAt(toLocalDateTimeString(new Date()));
+      setNotes('');
+    }
+  }, [isOpen, log]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setIsSubmitting(true);
     setError(null);
+    const body = {
+      medicationId,
+      taken,
+      takenAt: taken ? new Date(takenAt).toISOString() : undefined,
+      notes: notes || undefined,
+    };
     try {
-      await api.post('/api/medication-logs', {
-        medicationId,
-        taken,
-        takenAt: taken ? new Date(takenAt).toISOString() : undefined,
-        notes: notes || undefined,
-      });
+      if (log) {
+        await api.patch(`/api/medication-logs/${log.id}`, body);
+      } else {
+        await api.post('/api/medication-logs', body);
+      }
       onSuccess();
       onClose();
-      setNotes('');
-      setTaken(true);
-      setTakenAt(toLocalDateTimeString(new Date()));
     } catch (err) {
       if (axios.isAxiosError(err)) {
         setError((err.response?.data as ApiError)?.error ?? 'Failed to save. Please try again.');
@@ -71,7 +96,11 @@ export default function LogMedicationModal({ isOpen, onClose, onSuccess }: Props
   const noMeds = !loadingMeds && medications.length === 0;
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Log Medication">
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={log ? 'Edit Medication Log' : 'Log Medication'}
+    >
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
           <p role="alert" className="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-600">


### PR DESCRIPTION
## Summary
- Adds optional `log?: <LogType>` prop to all four log modals
- When `log` is provided: form pre-fills from the log's data; submit fires `PATCH /api/<type>-logs/:id`; modal title reads "Edit … Log"
- When `log` is absent: existing create behavior (POST) unchanged
- `LogHabitModal`: value fields now reset in the select `onChange` handler instead of a `useEffect`, avoiding a race with the pre-fill initialization
- All four modals pass `tsc -b` with no errors

## Test plan
- [ ] Dashboard quick-add still creates new logs (no regression)
- [ ] History page Edit button → modal opens pre-filled → Save sends PATCH
- [ ] Changing habit in edit mode resets value inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)