### PR TITLE
fix: correct Recharts labelFormatter type in TrendsPage

### DIFF
--- a/client/src/pages/TrendsPage.tsx
+++ b/client/src/pages/TrendsPage.tsx
@@ -265,7 +265,7 @@ export default function TrendsPage() {
                 width={24}
               />
               <Tooltip
-                labelFormatter={(v: string) => formatTooltipDate(v)}
+                labelFormatter={(v) => formatTooltipDate(String(v))}
                 contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', fontSize: 12 }}
               />
               <Legend iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 12 }} />
@@ -349,7 +349,7 @@ export default function TrendsPage() {
                 width={24}
               />
               <Tooltip
-                labelFormatter={(v: string) => formatTooltipDate(v)}
+                labelFormatter={(v) => formatTooltipDate(String(v))}
                 contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', fontSize: 12 }}
               />
               <Legend iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 12 }} />


### PR DESCRIPTION
## Summary
- Recharts v3 types the `labelFormatter` prop's first argument as `ReactNode`, not `string`
- Removed the explicit `string` type annotation and used `String(v)` to coerce the value
- Fixes the `TS2322` type errors at lines 268 and 352 that were causing `npm run build` to fail

## Test plan
- [ ] Run `npm run build` from `client/` — should exit 0 with no TypeScript errors
- [ ] Load the Trends page and verify tooltip date labels still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)