### PR TITLE
test: add integration tests for insights trends and export CSV endpoints

### DIFF
--- a/src/__tests__/export.integration.test.ts
+++ b/src/__tests__/export.integration.test.ts
@@ -1,0 +1,146 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const REGISTER = '/api/auth/register';
+const LOGIN = '/api/auth/login';
+const EXPORT = '/api/export/csv';
+
+const testUser = { email: 'user@export.welltrack', password: 'password123' };
+
+let accessToken: string;
+let userId: string;
+
+function recentDate(daysAgo: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+
+beforeAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@export.welltrack' } } });
+
+  const reg = await request(app).post(REGISTER).send(testUser);
+  userId = reg.body.user.id as string;
+  const login = await request(app).post(LOGIN).send(testUser);
+  accessToken = login.body.accessToken as string;
+
+  // One entry of each log type, 2 days ago
+  const symptom = await prisma.symptom.create({
+    data: { userId, name: 'Export Test Symptom', isActive: true },
+  });
+  await prisma.symptomLog.create({
+    data: { userId, symptomId: symptom.id, severity: 5, loggedAt: recentDate(2) },
+  });
+
+  await prisma.moodLog.create({
+    data: { userId, moodScore: 3, loggedAt: recentDate(2) },
+  });
+
+  const medication = await prisma.medication.create({
+    data: { userId, name: 'Export Test Med', isActive: true },
+  });
+  await prisma.medicationLog.create({
+    data: { userId, medicationId: medication.id, taken: true },
+  });
+
+  const habit = await prisma.habit.create({
+    data: { userId, name: 'Export Test Habit', trackingType: 'boolean', isActive: true },
+  });
+  await prisma.habitLog.create({
+    data: { userId, habitId: habit.id, valueBoolean: true, loggedAt: recentDate(2) },
+  });
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@export.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+describe('GET /api/export/csv', () => {
+  it('returns 200 with Content-Type text/csv', async () => {
+    const res = await request(app)
+      .get(EXPORT)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/csv/);
+  });
+
+  it('sets a Content-Disposition attachment header', async () => {
+    const res = await request(app)
+      .get(EXPORT)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.headers['content-disposition']).toMatch(/attachment; filename=/);
+  });
+
+  it('body contains all four section headers', async () => {
+    const res = await request(app)
+      .get(EXPORT)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.text).toContain('Symptom Logs');
+    expect(res.text).toContain('Mood Logs');
+    expect(res.text).toContain('Medication Logs');
+    expect(res.text).toContain('Habit Logs');
+  });
+
+  it('includes seeded data rows in the export', async () => {
+    const res = await request(app)
+      .get(EXPORT)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.text).toContain('Export Test Symptom');
+    expect(res.text).toContain('Export Test Med');
+    expect(res.text).toContain('Export Test Habit');
+  });
+
+  it('filters by date range — includes data when range covers seed data', async () => {
+    const start = recentDate(7).toISOString();
+    const end = new Date().toISOString();
+
+    const res = await request(app)
+      .get(`${EXPORT}?startDate=${start}&endDate=${end}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Export Test Symptom');
+  });
+
+  it('filters by date range — no data rows when range excludes all seed data', async () => {
+    const res = await request(app)
+      .get(`${EXPORT}?startDate=2020-01-01T00:00:00.000Z&endDate=2020-01-31T23:59:59.000Z`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    // Section headers still present
+    expect(res.text).toContain('Symptom Logs');
+    // But no seeded data rows
+    expect(res.text).not.toContain('Export Test Symptom');
+  });
+
+  it('returns 422 for an invalid startDate', async () => {
+    const res = await request(app)
+      .get(`${EXPORT}?startDate=not-a-date`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(422);
+    expect(res.body).toEqual({ error: 'Invalid startDate' });
+  });
+
+  it('returns 422 for an invalid endDate', async () => {
+    const res = await request(app)
+      .get(`${EXPORT}?endDate=not-a-date`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(422);
+    expect(res.body).toEqual({ error: 'Invalid endDate' });
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).get(EXPORT);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/__tests__/insights.integration.test.ts
+++ b/src/__tests__/insights.integration.test.ts
@@ -1,0 +1,221 @@
+import request from 'supertest';
+import app from '../app';
+import prisma from '../lib/prisma';
+
+const REGISTER = '/api/auth/register';
+const LOGIN = '/api/auth/login';
+const TRENDS = '/api/insights/trends';
+const ACTIVITY = '/api/insights/activity';
+
+const testUser = { email: 'user@insights.welltrack', password: 'password123' };
+
+let accessToken: string;
+let userId: string;
+let symptomId: string;
+
+// Seed logs close to today so they fall within any days window (7/30/90)
+function recentDate(daysAgo: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+
+beforeAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@insights.welltrack' } } });
+
+  const reg = await request(app).post(REGISTER).send(testUser);
+  userId = reg.body.user.id as string;
+  const login = await request(app).post(LOGIN).send(testUser);
+  accessToken = login.body.accessToken as string;
+
+  // 3 mood logs: 2 days ago (score 2) and yesterday (score 4 twice — avg 4)
+  await prisma.moodLog.createMany({
+    data: [
+      { userId, moodScore: 2, energyLevel: 1, stressLevel: 5, loggedAt: recentDate(2) },
+      { userId, moodScore: 4, energyLevel: 3, stressLevel: 3, loggedAt: recentDate(1) },
+      { userId, moodScore: 4, energyLevel: 5, stressLevel: 1, loggedAt: recentDate(1) },
+    ],
+  });
+
+  // Custom symptom + 2 severity logs
+  const symptom = await prisma.symptom.create({
+    data: { userId, name: 'Insights Test Headache', category: 'pain', isActive: true },
+  });
+  symptomId = symptom.id;
+
+  await prisma.symptomLog.createMany({
+    data: [
+      { userId, symptomId, severity: 3, loggedAt: recentDate(2) },
+      { userId, symptomId, severity: 7, loggedAt: recentDate(1) },
+    ],
+  });
+});
+
+afterAll(async () => {
+  await prisma.user.deleteMany({ where: { email: { endsWith: '@insights.welltrack' } } });
+  await prisma.$disconnect();
+});
+
+describe('GET /api/insights/trends', () => {
+  it('returns 200 with mood trend as array of { date, avg }', async () => {
+    const res = await request(app)
+      .get(`${TRENDS}?type=mood&days=7`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body[0]).toHaveProperty('date');
+    expect(res.body[0]).toHaveProperty('avg');
+    expect(typeof res.body[0].avg).toBe('number');
+  });
+
+  it('averages multiple logs on the same day', async () => {
+    // Yesterday has 2 mood logs: score 4 and 4 → avg 4
+    const res = await request(app)
+      .get(`${TRENDS}?type=mood&days=7`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    const latestPoint = res.body[res.body.length - 1] as { date: string; avg: number };
+    expect(latestPoint.avg).toBe(4);
+  });
+
+  it('returns results sorted ascending by date', async () => {
+    const res = await request(app)
+      .get(`${TRENDS}?type=mood&days=7`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    const dates = res.body.map((p: { date: string }) => p.date);
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i] >= dates[i - 1]).toBe(true);
+    }
+  });
+
+  it('returns energy trend data', async () => {
+    const res = await request(app)
+      .get(`${TRENDS}?type=energy&days=7`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('returns stress trend data', async () => {
+    const res = await request(app)
+      .get(`${TRENDS}?type=stress&days=30`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('returns symptom severity trend for a valid symptom UUID', async () => {
+    const res = await request(app)
+      .get(`${TRENDS}?type=${symptomId}&days=30`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body[0]).toHaveProperty('avg');
+  });
+
+  it('returns 404 for a non-existent symptom UUID', async () => {
+    const res = await request(app)
+      .get(`${TRENDS}?type=00000000-0000-0000-0000-000000000000&days=30`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 422 when type param is missing', async () => {
+    const res = await request(app)
+      .get(`${TRENDS}?days=30`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(422);
+    expect(res.body).toHaveProperty('error');
+    expect(typeof res.body.error).toBe('string');
+  });
+
+  it('defaults to 30 days when days param is invalid', async () => {
+    const res = await request(app)
+      .get(`${TRENDS}?type=mood&days=14`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Not an error — invalid days defaults to 30
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).get(`${TRENDS}?type=mood&days=7`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/insights/activity', () => {
+  it('returns 200 with activity as array of { date, count }', async () => {
+    const res = await request(app)
+      .get(`${ACTIVITY}?days=7`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body[0]).toHaveProperty('date');
+    expect(res.body[0]).toHaveProperty('count');
+  });
+
+  it('each count is a non-negative integer', async () => {
+    const res = await request(app)
+      .get(`${ACTIVITY}?days=30`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    for (const point of res.body as { count: number }[]) {
+      expect(typeof point.count).toBe('number');
+      expect(point.count).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('aggregates across all log types', async () => {
+    // Seeded 3 mood logs + 2 symptom logs = 5 total entries
+    const res = await request(app)
+      .get(`${ACTIVITY}?days=7`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    const total = (res.body as { count: number }[]).reduce((s, p) => s + p.count, 0);
+    expect(total).toBeGreaterThanOrEqual(5);
+  });
+
+  it('returns results sorted ascending by date', async () => {
+    const res = await request(app)
+      .get(`${ACTIVITY}?days=30`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    const dates = res.body.map((p: { date: string }) => p.date);
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i] >= dates[i - 1]).toBe(true);
+    }
+  });
+
+  it('defaults to 30 days when days param is invalid', async () => {
+    const res = await request(app)
+      .get(`${ACTIVITY}?days=99`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).get(`${ACTIVITY}?days=7`);
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Type
Test

## Summary
- The Phase 3 insights and export endpoints were shipped without test coverage — this adds the two missing test files
- Follows the exact same pattern as all 41 existing integration test files (supertest + real DB, unique email domain isolation, Prisma seeding, cascade cleanup)
- No production code changed; all fixes came from writing tests correctly

## New files
| File | Tests |
|---|---|
| `src/__tests__/insights.integration.test.ts` | 16 tests — `GET /api/insights/trends` (mood/energy/stress/symptom UUID, averaging, sort, validation, 401) and `GET /api/insights/activity` (shape, counts, cross-log aggregation, sort, 401) |
| `src/__tests__/export.integration.test.ts` | 9 tests — `GET /api/export/csv` (content-type, Content-Disposition, all 4 section headers, data rows, date-range filtering, invalid date 422, 401) |

## Test plan
- [x] `npx jest src/__tests__/insights.integration.test.ts src/__tests__/export.integration.test.ts` — 25/25 pass
- [x] `npm test` — 316/316 pass across all 43 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)