### PR TITLE
docs: add BACKLOG.md for future feature ideas

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,58 @@
+# BACKLOG.md — Future Feature Ideas
+
+This file is a parking lot for features and improvements that aren't yet scheduled. Items here are **not committed work** — they're ideas worth revisiting.
+
+## How to promote an idea to implementation
+
+1. If the idea changes product scope, update `Requirements.md`
+2. Add concrete checkboxes to `tasks.md` under the appropriate phase
+3. **Delete the item from this file** (git history and the PR record serve as the audit trail)
+
+---
+
+## User Profile & Account
+
+- [ ] Add pronouns field to profile
+- [ ] Add phone number field to profile
+- [ ] Profile picture upload (avatar)
+- [ ] Allow user to change their email address
+- [ ] Email verification — send a confirmation link; show a green verified badge on the profile once confirmed
+- [ ] Show last login date/time on the profile page
+- [ ] Two-factor authentication (TOTP / authenticator app)
+- [ ] Account deletion with full data erasure (GDPR right-to-erasure)
+
+## Trends & Analytics
+
+- [ ] Add 60-day, 120-day, and 365-day options to the date range selector (currently 7/30/90)
+- [ ] Correlation view — overlay two metrics (e.g., mood vs. energy) on the same chart
+- [ ] Printable / shareable summary report for sharing with a healthcare provider
+- [ ] Customizable dashboard — let users pin/unpin widgets and reorder cards
+
+## Notifications & Reminders
+
+- [ ] Daily logging reminder (email or push notification)
+- [ ] Medication reminder alerts
+- [ ] Streak milestone celebrations / badges (e.g., 7-day, 30-day streak)
+- [ ] Weekly wellness summary email digest
+
+## Data & Integrations
+
+- [ ] PDF export of logs and trend charts
+- [ ] Bulk CSV import of historical data
+- [ ] Apple Health / Google Fit integration (read activity and sleep data)
+- [ ] Wearable device sync (Fitbit, Garmin)
+
+## App Experience & Support
+
+- [ ] Help page — FAQs and how-to guides
+- [ ] Contact us page — support form or mailto link
+- [ ] In-app link to API documentation (e.g., Swagger/OpenAPI viewer)
+- [ ] Dark mode / light-dark theme toggle
+- [ ] Progressive Web App (PWA) — installable on mobile home screen, basic offline caching
+- [ ] Multi-language / i18n support
+
+## Platform & Infrastructure
+
+- [ ] Admin dashboard — aggregate usage stats (no PII) for monitoring platform health
+- [ ] Per-user rate limiting hardening (beyond global express-rate-limit)
+- [ ] Audit log — record sensitive account events (password change, email change, new-device login)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,7 @@ Each checkbox in `tasks.md` gets its own branch and PR. This means if a section 
 | `DEVELOPMENT.md` | Human onboarding — first-time setup, env vars, day-to-day commands | Setup steps change, a new service is added, or a new env var is required |
 | `Requirements.md` | Original product requirements | Scope changes (treat as read-only otherwise) |
 | `tasks.md` | Living task checklist | A task is completed — check the box in the **same commit** as the code |
+| `BACKLOG.md` | Future feature ideas — unscheduled, unchecked | An idea is added, promoted to `tasks.md`, or removed |
 
 **Rules:**
 - Keep `CLAUDE.md` accurate — stale architecture notes lead to incorrect suggestions


### PR DESCRIPTION
## Summary

- Creates `BACKLOG.md` at the project root as a parking lot for unscheduled feature ideas
- Organizes 26 ideas across 6 categories: User Profile & Account, Trends & Analytics, Notifications & Reminders, Data & Integrations, App Experience & Support, Platform & Infrastructure
- Includes a header explaining how to promote an idea to `tasks.md` when ready to implement
- Adds a `BACKLOG.md` row to the documentation table in `CLAUDE.md` so future sessions know the file exists and when to update it

**Type:** Documentation

## Test plan

- [ ] Confirm `BACKLOG.md` appears at the project root and renders correctly as markdown
- [ ] Confirm the new row in the `CLAUDE.md` docs table is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)