### PR TITLE
fix: dashboard stats always show 0 (#77)

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -75,7 +75,7 @@ export default function DashboardPage() {
 
   useEffect(() => {
     const { weekStart, today } = getWeekRange();
-    const params = { startDate: weekStart, endDate: today };
+    const params = { startDate: weekStart, endDate: `${today}T23:59:59.999Z` };
 
     setIsLoading(true);
     // Fetch the full week so we can derive both today's counts and the streak


### PR DESCRIPTION
## Type
Bug Fix

## Root cause

`DashboardPage` built the API query params as:

```js
const params = { startDate: weekStart, endDate: today };
// today = '2026-02-22' (date-only string)
```

The backend controller parses `endDate` with `new Date('2026-02-22')`, which resolves to **`2026-02-22T00:00:00.000Z` — midnight UTC**. The Prisma query becomes:

```
loggedAt >= weekStart AND loggedAt <= 2026-02-22T00:00:00.000Z
```

Any entry logged after midnight UTC (i.e. any entry made during the day) fails the `lte` filter. The API returns an empty array, so all four stat cards display 0 and the streak dots are all empty.

## Fix

One line: append `T23:59:59.999Z` to the `endDate` so the query covers the full UTC day.

```diff
- const params = { startDate: weekStart, endDate: today };
+ const params = { startDate: weekStart, endDate: `${today}T23:59:59.999Z` };
```

## Testing checklist

- [ ] Log at least one symptom, mood, medication, and habit entry for today
- [ ] Reload the Dashboard — all four stat cards should show the correct non-zero counts
- [ ] The streak dot for today should be filled (teal)
- [ ] `npm run build` in `client/` passes with no TypeScript errors

Closes #77