### PR TITLE
perf: code-split TrendsPage to reduce initial bundle size

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -8,8 +9,12 @@ import ForgotPasswordPage from './pages/ForgotPasswordPage';
 import ResetPasswordPage from './pages/ResetPasswordPage';
 import DashboardPage from './pages/DashboardPage';
 import HistoryPage from './pages/HistoryPage';
-import TrendsPage from './pages/TrendsPage';
 import SettingsPage from './pages/SettingsPage';
+
+// Lazy-load TrendsPage so Recharts is split into a separate chunk and excluded
+// from the initial bundle. The page is rarely the entry point, so the small
+// waterfall on first visit is an acceptable trade-off.
+const TrendsPage = lazy(() => import('./pages/TrendsPage'));
 
 export default function App() {
   return (
@@ -27,7 +32,14 @@ export default function App() {
             <Route element={<AppLayout />}>
               <Route path="/" element={<DashboardPage />} />
               <Route path="/history" element={<HistoryPage />} />
-              <Route path="/trends" element={<TrendsPage />} />
+              <Route
+                path="/trends"
+                element={
+                  <Suspense fallback={<div className="flex items-center justify-center h-64 text-gray-400">Loading…</div>}>
+                    <TrendsPage />
+                  </Suspense>
+                }
+              />
               <Route path="/settings" element={<SettingsPage />} />
             </Route>
           </Route>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -8,6 +8,17 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          // Keep Recharts (and its transitive deps) in a separate vendor chunk so
+          // it is only downloaded when the user first navigates to the Trends page.
+          recharts: ['recharts'],
+        },
+      },
+    },
+  },
   server: {
     proxy: {
       '/api': {

--- a/tasks.md
+++ b/tasks.md
@@ -205,7 +205,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 
 - [x] Review all Prisma queries — ensure `where` clauses on `user_id` and `logged_at` are using the indexed fields
 - [x] Add pagination to all `GET` list endpoints that could return large data sets (confirm `limit` + `offset` work correctly)
-- [ ] Audit the React bundle size with `vite build --report`; code-split the Trends page if the charting library is large
+- [x] Audit the React bundle size with `vite build --report`; code-split the Trends page if the charting library is large
 - [ ] Confirm all API responses include `Content-Type: application/json` and proper status codes
 
 ### Deployment


### PR DESCRIPTION
## Type
Performance

## Summary
- Ran `vite build` to audit bundle sizes — single chunk was **687 KB (207 KB gzip)**, exceeding Vite's 500 KB warning
- Recharts (the charting library used only by TrendsPage) was identified as the primary contributor at ~360 KB
- Lazy-loaded `TrendsPage` with `React.lazy()` + `Suspense` in `App.tsx`
- Added `manualChunks: { recharts: ['recharts'] }` in `vite.config.ts` so Recharts is explicitly placed in its own async vendor chunk

### Bundle before vs after
| Chunk | Before | After |
|---|---|---|
| `index.js` (initial) | 687 KB / 207 KB gzip | 321 KB / **97 KB gzip** |
| `recharts.js` (lazy) | — | 361 KB / 108 KB gzip |
| `TrendsPage.js` (lazy) | — | 7 KB / 2.5 KB gzip |

Initial JS payload reduced by **~53%**. Recharts is now only downloaded when the user first navigates to `/trends`.

## Test plan
- [ ] `npm run build` in `client/` — no chunk size warning, three separate JS chunks emitted
- [ ] Start dev server (`npm run dev` in `client/`) — Dashboard, History, Settings all load without fetching recharts
- [ ] Navigate to `/trends` — page loads correctly with the loading fallback briefly visible, charts render
- [ ] Network tab: confirm `recharts-*.js` is only fetched on first `/trends` visit