### PR TITLE
docs: add CLAUDE.md auto-load imports, backlog item, and update progress.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Auto-loaded context files
+
+The following files are imported automatically into every session so their contents are always in context:
+
+- Task checklist and workflow rules: @docs/tasks.md
+- Product requirements and scope: @docs/Requirements.md
+
 ## Commands
 
 ```bash

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -56,3 +56,7 @@ This file is a parking lot for features and improvements that aren't yet schedul
 - [ ] Admin dashboard — aggregate usage stats (no PII) for monitoring platform health
 - [ ] Per-user rate limiting hardening (beyond global express-rate-limit)
 - [ ] Audit log — record sensitive account events (password change, email change, new-device login)
+
+## Documentation
+
+- [ ] Rename API-related docs to follow the `<name>-API.md` convention (e.g., `authentication-API.md`, `symptoms-API.md`) so API reference files are immediately distinguishable from guides and overviews

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -20,27 +20,30 @@ All backend foundation, frontend foundation, and full-feature work is done and m
 
 | Task | PR | Notes |
 |---|---|---|
-| Unit tests for auth service functions | [#71](https://github.com/JohnnyLeuthard/welltrack/pull/71) | 13 tests: password hashing (bcrypt format, verify/reject), access token (valid JWT, claims, 15-min TTL, tamper rejection), refresh token (valid JWT, jti uniqueness, 7-day TTL) |
+| Unit tests for auth service functions | [#71](https://github.com/JohnnyLeuthard/welltrack/pull/71) | 13 tests: bcrypt hashing, JWT claims, token TTLs, tamper rejection |
 | Integration tests for auth endpoints | [#72](https://github.com/JohnnyLeuthard/welltrack/pull/72) | Already existed from Phase 1 — checked off |
-| Integration tests for CRUD resource | [#73](https://github.com/JohnnyLeuthard/welltrack/pull/73) | Already existed from Phase 1 — checked off (24 test files covering all 6 resources) |
-| Mobile layout at 375px | [#74](https://github.com/JohnnyLeuthard/welltrack/pull/74) | Fixed sidebar crushing content on mobile (added bottom nav, `sm:hidden` sidebar); all 4 modal footers now full-width on mobile; fixed pre-existing TS error in TrendsPage |
-| End-to-end full user flow test | [#75](https://github.com/JohnnyLeuthard/welltrack/pull/75) | 10-step test: register → create symptom → log entry → history → trends → activity → export CSV → delete account → verify DB deletion → verify token rejection |
+| Integration tests for CRUD resource | [#73](https://github.com/JohnnyLeuthard/welltrack/pull/73) | Already existed from Phase 1 — checked off (24 test files, all 6 resources) |
+| Mobile layout at 375px | [#74](https://github.com/JohnnyLeuthard/welltrack/pull/74) | Fixed sidebar on mobile (bottom nav + `sm:hidden`); modal footers full-width |
+| End-to-end full user flow test | [#75](https://github.com/JohnnyLeuthard/welltrack/pull/75) | 10-step E2E: register → log → history → trends → export → delete account |
 
 ### Phase 4 Performance: Complete ✅
 
 | Task | PR | Notes |
 |---|---|---|
-| Review Prisma queries + add userId indexes | [#76](https://github.com/JohnnyLeuthard/welltrack/pull/76) | Added missing `@@index([userId])` to `Symptom`, `Habit`, and `Medication` models; confirmed all `where` clauses target indexed fields |
-| Pagination on GET list endpoints | [#78](https://github.com/JohnnyLeuthard/welltrack/pull/78) | Added `limit` + `offset` query params to `GET /api/symptoms`, `GET /api/habits`, `GET /api/medications` |
-| Dashboard stats bug fix | [#79](https://github.com/JohnnyLeuthard/welltrack/pull/79) | Fixed `endDate` being truncated to midnight UTC; today's stats always showed 0 |
-| Bundle audit + code-split Trends page | [#80](https://github.com/JohnnyLeuthard/welltrack/pull/80) | Lazy-loaded `TrendsPage` with `React.lazy` + `Suspense`; added `manualChunks: { recharts }` in `vite.config.ts`; initial bundle: 207 KB → 97 KB gzip (−53%) |
-| Confirm API Content-Type and status codes | [#81](https://github.com/JohnnyLeuthard/welltrack/pull/81) | Full audit — all JSON endpoints use `res.json()` (auto Content-Type); fixed `DELETE /api/symptoms/:id` returning `200` instead of `204` (inconsistent with all other DELETE handlers) |
+| Review Prisma queries + add userId indexes | [#76](https://github.com/JohnnyLeuthard/welltrack/pull/76) | Added `@@index([userId])` to `Symptom`, `Habit`, `Medication`; confirmed all `where` clauses use indexed fields |
+| Pagination on GET list endpoints | [#78](https://github.com/JohnnyLeuthard/welltrack/pull/78) | `limit` + `offset` added to `GET /api/symptoms`, `/api/habits`, `/api/medications` |
+| Dashboard stats bug fix | [#79](https://github.com/JohnnyLeuthard/welltrack/pull/79) | Fixed `endDate` truncated to midnight UTC — today's counts always showed 0 |
+| Bundle audit + code-split Trends page | [#80](https://github.com/JohnnyLeuthard/welltrack/pull/80) | `React.lazy` + `Suspense` for TrendsPage; `manualChunks: { recharts }` in vite.config; initial bundle 207 KB → 97 KB gzip (−53%) |
+| API Content-Type and status code audit | [#81](https://github.com/JohnnyLeuthard/welltrack/pull/81) | All JSON endpoints confirmed correct; fixed `DELETE /api/symptoms/:id` returning `200` instead of `204` |
 
-### Documentation additions (merged)
+### Documentation overhaul (post-Phase 3)
 
-- **`BACKLOG.md`** — [PR #70](https://github.com/JohnnyLeuthard/welltrack/pull/70) — 26 future feature ideas across 6 categories
-- **`OVERVIEW.md`** — Public-facing product overview (what WellTrack is, who it's for, key features)
-- **`TECHNICAL.md`** — Technical reference for engineering and support staff (stack, costs, deployment, ops)
+| Work | PR | Notes |
+|---|---|---|
+| BACKLOG.md created | [#70](https://github.com/JohnnyLeuthard/welltrack/pull/70) | 27 future feature ideas across 7 categories (including new Documentation category) |
+| OVERVIEW.md + TECHNICAL.md created; progress.md formalized | [#82](https://github.com/JohnnyLeuthard/welltrack/pull/82) | OVERVIEW.md: public-facing product pitch; TECHNICAL.md: stack, costs, ops reference; progress.md: living status doc |
+| All docs moved to `docs/` folder | [#83](https://github.com/JohnnyLeuthard/welltrack/pull/83) | Root cleaned up; CLAUDE.md stays at root (required); all cross-references updated; docs table in CLAUDE.md expanded |
+| CLAUDE.md auto-load imports added | _(this session)_ | `@docs/tasks.md` and `@docs/Requirements.md` auto-loaded into every Claude Code session so workflow rules and product scope are always in context |
 
 ---
 
@@ -53,44 +56,100 @@ Phase 1  ████████████████████  100%  (al
 Phase 2  ████████████████████  100%  (all checkboxes ✅)
 Phase 3  ████████████████████  100%  (all checkboxes ✅)
 Phase 4  ████████████░░░░░░░░   56%  (9/16 checkboxes ✅)
-         └─ Testing    ✅ 5/5
+         └─ Testing     ✅ 5/5
          └─ Performance ✅ 4/4
          └─ Deployment  ⬜ 0/7
 ```
 
 ### Test coverage (backend)
 
-- **45 test files**, 351 assertions (all passing)
-- Auth: register, login, refresh, logout, forgot-password, reset-password, middleware
-- Resources: full CRUD (POST/GET/PATCH/DELETE) for mood logs, symptoms, symptom logs, medications, medication logs, habits, habit logs
-- Insights: trends endpoint + activity heatmap endpoint
-- Export: CSV export endpoint
-- Auth service unit tests: bcrypt hashing, JWT generation/validation
-- E2E: full 10-step user journey
+- **45 test files**, 351 assertions — all passing
+- Auth, all 6 CRUD resources, insights, export, E2E user journey
+- Zero mocking — all tests run against a real PostgreSQL instance
+
+### Repository structure (as of today)
+
+```
+/                   ← repo root
+  CLAUDE.md         ← AI agent guidance (must stay at root)
+  src/              ← backend TypeScript source
+  client/           ← React/Vite frontend
+  prisma/           ← schema, migrations, seed
+  docs/             ← all other documentation
+    tasks.md
+    Requirements.md
+    DEVELOPMENT.md
+    OVERVIEW.md
+    TECHNICAL.md
+    BACKLOG.md
+    progress.md
+```
 
 ---
 
-## Next steps — Phase 4 Deployment (7 tasks remaining)
+## Immediate next steps — Phase 4 Deployment (7 tasks)
 
-1. **Set up production PostgreSQL** — Railway or Render managed database
-2. **Run `prisma migrate deploy` + seed** against production DB
-3. **Deploy backend** to Railway or Render with all required env vars (`DATABASE_URL`, `JWT_SECRET`, `JWT_REFRESH_SECRET`)
-4. **Deploy frontend** to Vercel with `VITE_API_URL` pointing to the production backend
-5. **Confirm HTTPS** is active on both services
-6. **Production smoke test** — register, log one entry of each type, view trends, export CSV
-7. **Set up uptime monitoring** — UptimeRobot free tier or equivalent
+These are the remaining checked tasks in `docs/tasks.md`. Complete in order:
+
+1. **Set up production PostgreSQL** — Railway (`$5/mo`) or Render Starter (`$7/mo`); avoid free-tier expiry on Render
+2. **Run `prisma migrate deploy` + seed** — apply all migrations against production DB; seed system symptoms and habits
+3. **Deploy backend** — Railway or Render with env vars: `DATABASE_URL`, `JWT_SECRET`, `JWT_REFRESH_SECRET`, `CLIENT_ORIGIN`
+4. **Deploy frontend** — Vercel (free hobby tier); set `VITE_API_URL` to production backend URL
+5. **Confirm HTTPS** — both services should auto-provision TLS; verify no mixed-content warnings
+6. **Production smoke test** — register a new user, log one entry of each type, view trends, export CSV
+7. **Uptime monitoring** — UptimeRobot free tier; monitor `GET /health` every 5 minutes
+
+---
+
+## Suggested next steps (post-deployment)
+
+These are not in `docs/tasks.md` yet but are high-value follow-ups worth scheduling soon after launch.
+
+### High priority — launch blockers or near-blockers
+
+| Item | Why it matters |
+|---|---|
+| **Add a `README.md` at the repo root** | GitHub shows README on the repo homepage; currently there's nothing there. Should link to `docs/OVERVIEW.md`, `docs/DEVELOPMENT.md`, and the live app URL |
+| **Wire up real email delivery** | Password reset emails are currently `console.log`'d — the feature is broken in production. Needs a real provider: SendGrid (free tier: 100/day), Postmark, or AWS SES (~$0.10/1000 emails) |
+| **GitHub Actions CI pipeline** | Run `npm test` automatically on every PR so regressions are caught before review. A basic workflow file is 15 lines of YAML |
+
+### Medium priority — meaningfully improves the product
+
+| Item | Why it matters |
+|---|---|
+| **Rate limiting** | No per-IP or per-user rate limiting exists yet — the app is vulnerable to brute-force on the auth endpoints in production |
+| **Swagger / OpenAPI docs** | Auto-generated API docs from route definitions; makes the API usable by future integrations and is already in the BACKLOG |
+| **Timezone display** | User timezone is stored but logs are displayed in UTC in the UI — a frequent pain point for users not in UTC |
+| **Correlation insights** | "You sleep worse on days with high caffeine" — the most-requested feature type for chronic illness trackers; data is already there |
+
+### Longer term — when the user base grows
+
+| Item | Why it matters |
+|---|---|
+| **PDF export** | More useful than CSV for sharing with doctors; already in BACKLOG |
+| **Daily email digest / reminders** | Drives retention and consistent logging habit; depends on real email being wired up first |
+| **PWA / installable app** | Adds to mobile home screen, improves the mobile experience significantly without requiring a native app |
+| **Connection pooling (PgBouncer)** | At ~500+ concurrent users the single Prisma connection pool will become a bottleneck |
 
 ---
 
 ## Remaining work at a glance
 
 ```
-Phase 4 Deployment (7 tasks)
-  [ ] Production database setup (Railway or Render)
+Phase 4 Deployment (7 tasks — in docs/tasks.md)
+  [ ] Production database setup
   [ ] Run migrations + seed on production
   [ ] Backend deployment with env vars
   [ ] Frontend deployment (Vercel) with VITE_API_URL
-  [ ] HTTPS confirmation on both services
+  [ ] HTTPS confirmation
   [ ] Production smoke test
-  [ ] Uptime monitoring setup
+  [ ] Uptime monitoring
+
+Post-launch suggestions (not yet in tasks.md)
+  [ ] README.md at repo root
+  [ ] Real email delivery (SendGrid / Postmark / SES)
+  [ ] GitHub Actions CI
+  [ ] Rate limiting on auth endpoints
+  [ ] Timezone display fix
+  [ ] Swagger/OpenAPI docs
 ```


### PR DESCRIPTION
## Summary

- Added `@docs/tasks.md` and `@docs/Requirements.md` auto-load imports to `CLAUDE.md` so the task checklist and product requirements are always in context after `/clear` — the docs move in #83 would have otherwise broken the implicit assumption that Claude always knows where to find those files
- Added a **Documentation** section to `docs/BACKLOG.md` with one item: rename API-related docs to follow the `<name>-API.md` convention
- Rewrote `docs/progress.md` to reflect all recent work: documentation overhaul PRs (#70, #82, #83), repository structure diagram, and prioritized post-deployment suggestion tables (high / medium / longer-term)

**Type:** Documentation

## Testing checklist

- [ ] `CLAUDE.md` opens a new session and `@docs/tasks.md` / `@docs/Requirements.md` contents are in context
- [ ] `docs/BACKLOG.md` Documentation section is present and correctly formatted
- [ ] `docs/progress.md` accurately reflects Phase 4 progress (9/16, 56%) and the 7 remaining Deployment tasks