### PR TITLE
feat: add 60, 120, and 365-day options to trends date range selector

### DIFF
--- a/client/src/pages/TrendsPage.tsx
+++ b/client/src/pages/TrendsPage.tsx
@@ -12,9 +12,9 @@ import {
 import api from '../services/api';
 import type { ActivityPoint, Symptom, TrendPoint } from '../types/api';
 
-type Days = 7 | 30 | 90;
+type Days = 7 | 30 | 60 | 90 | 120 | 365;
 
-const DAY_OPTIONS: Days[] = [7, 30, 90];
+const DAY_OPTIONS: Days[] = [7, 30, 60, 90, 120, 365];
 
 // Mood chart line colours
 const MOOD_LINES = [
@@ -52,6 +52,9 @@ function formatAxisDate(date: string, days: Days): string {
   const d = new Date(date + 'T12:00:00');
   if (days === 7) {
     return d.toLocaleDateString('en-US', { weekday: 'short', month: 'numeric', day: 'numeric' });
+  }
+  if (days === 365) {
+    return d.toLocaleDateString('en-US', { month: 'short' });
   }
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -23,8 +23,6 @@ This file is a parking lot for features and improvements that aren't yet schedul
 
 ## Trends & Analytics
 
-- [ ] Add 60-day, 120-day, and 365-day options to the date range selector (currently 7/30/90)
-- [ ] Correlation view — overlay two metrics (e.g., mood vs. energy) on the same chart
 - [ ] Printable / shareable summary report for sharing with a healthcare provider
 - [ ] Customizable dashboard — let users pin/unpin widgets and reorder cards
 
@@ -60,3 +58,4 @@ This file is a parking lot for features and improvements that aren't yet schedul
 ## Documentation
 
 - [ ] Rename API-related docs to follow the `<name>-API.md` convention (e.g., `authentication-API.md`, `symptoms-API.md`) so API reference files are immediately distinguishable from guides and overviews
+- [ ] Cleanup the fac t there are tow document folders docs and documentation. Add something to name to indicate why or merge them. Move files arounbd as needed

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -217,3 +217,26 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 - [ ] Confirm HTTPS is enabled on both frontend and backend
 - [ ] Smoke test the deployed app: register a new user, log one entry of each type, view trends, export CSV
 - [ ] Set up basic uptime monitoring (UptimeRobot free tier or similar)
+
+---
+
+## Phase 5: Enhancements
+
+### Frontend Features
+
+- [x] Add 60-day, 120-day, and 365-day options to the trends date range selector (update frontend selector and confirm backend accepts new `days` values)
+- [ ] Dark mode toggle — add a light/dark theme switch to the Settings page; persist preference in `localStorage`; apply via Tailwind's `darkMode: 'class'` config
+- [ ] Correlation chart — add a second metric overlay to the Trends chart so users can compare two metrics (e.g., mood vs. energy) on the same axis
+- [ ] Help page — add a `/help` route with FAQs and how-to guides for logging, viewing trends, and exporting data
+- [ ] Contact page — add a `/contact` route with a support mailto link and links to relevant help resources
+
+### Backend + Frontend
+
+- [ ] Track last login — store `last_login_at` on the `User` model; update it on successful login; expose it in `GET /api/users/me`; display it on the Settings profile section
+- [ ] Allow email change — extend `PATCH /api/users/me` to accept a new `email` field with uniqueness validation; add an email field to the profile form in Settings
+- [ ] Per-user rate limiting — add per-user rate limiting middleware (e.g., `express-rate-limit` keyed by `req.user.userId`) to protect write endpoints from abuse
+- [ ] Audit log — record sensitive account events (password change, email change, login) to a new `AuditLog` model; expose `GET /api/users/me/audit-log` for the authenticated user to view their own history
+
+### Export
+
+- [ ] PDF export — add `GET /api/export/pdf` endpoint using `pdfkit`; include log summaries and trend data; add a "Download PDF" button to the Settings > Export section

--- a/src/controllers/insights.controller.ts
+++ b/src/controllers/insights.controller.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from 'express';
 import { getActivity, getMoodTrend, getSymptomTrend } from '../services/insights.service';
 
-const VALID_DAYS = [7, 30, 90];
+const VALID_DAYS = [7, 30, 60, 90, 120, 365];
 const MOOD_METRICS = ['mood', 'energy', 'stress'] as const;
 
 export async function getTrends(req: Request, res: Response): Promise<void> {


### PR DESCRIPTION
## Type
Task

## Summary
- Extended `VALID_DAYS` in `insights.controller.ts` to accept `60`, `120`, and `365` in addition to the existing `7`, `30`, `90`
- Added `60 | 120 | 365` to the `Days` union type and `DAY_OPTIONS` array in `TrendsPage.tsx`
- Updated `formatAxisDate` to show month-only labels on the 365-day view (avoids axis clutter)
- Checked the task off in `docs/tasks.md` and removed the promoted item from `docs/BACKLOG.md`

## Testing checklist
- [ ] Navigate to `/trends` — buttons for 60, 120, and 365 days appear in the selector row
- [ ] Click each new option — charts and heatmap re-fetch and render for the new range
- [ ] 365-day axis shows month abbreviations only (e.g., "Jan", "Feb"); shorter ranges still show "Jan 5" format
- [ ] `GET /api/insights/trends?type=mood&days=60` returns data (not a 30-day default fallback)
- [ ] `GET /api/insights/activity?days=365` returns data for the full year

🤖 Generated with [Claude Code](https://claude.com/claude-code)