### PR TITLE
feat: add dark mode toggle to Settings with full app theming

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
+import { ThemeProvider } from './context/ThemeContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import AppLayout from './components/AppLayout';
 import RegisterPage from './pages/RegisterPage';
@@ -18,6 +19,7 @@ const TrendsPage = lazy(() => import('./pages/TrendsPage'));
 
 export default function App() {
   return (
+    <ThemeProvider>
     <BrowserRouter>
       <AuthProvider>
         <Routes>
@@ -49,5 +51,6 @@ export default function App() {
         </Routes>
       </AuthProvider>
     </BrowserRouter>
+    </ThemeProvider>
   );
 }

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -12,9 +12,9 @@ export default function AppLayout() {
   const { user, logout } = useAuth();
 
   return (
-    <div className="flex min-h-screen bg-gray-50">
+    <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900">
       {/* Sidebar — desktop only */}
-      <aside className="hidden sm:flex w-56 shrink-0 flex-col border-r border-gray-200 bg-white">
+      <aside className="hidden sm:flex w-56 shrink-0 flex-col border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
         <div className="px-6 py-5">
           <span className="text-lg font-semibold text-teal-600">WellTrack</span>
         </div>
@@ -29,8 +29,8 @@ export default function AppLayout() {
                 [
                   'flex items-center rounded-md px-3 py-2 text-sm transition-colors',
                   isActive
-                    ? 'bg-teal-50 font-medium text-teal-700'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
+                    ? 'bg-teal-50 dark:bg-teal-900/30 font-medium text-teal-700 dark:text-teal-300'
+                    : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-gray-100',
                 ].join(' ')
               }
             >
@@ -39,16 +39,16 @@ export default function AppLayout() {
           ))}
         </nav>
 
-        <div className="border-t border-gray-100 px-4 py-4">
-          <p className="mb-0.5 truncate text-sm font-medium text-gray-700">
+        <div className="border-t border-gray-100 dark:border-gray-700 px-4 py-4">
+          <p className="mb-0.5 truncate text-sm font-medium text-gray-700 dark:text-gray-200">
             {user?.displayName ?? user?.email}
           </p>
           {user?.displayName && (
-            <p className="mb-3 truncate text-xs text-gray-400">{user.email}</p>
+            <p className="mb-3 truncate text-xs text-gray-400 dark:text-gray-500">{user.email}</p>
           )}
           <button
             onClick={() => void logout()}
-            className="text-xs text-gray-500 hover:text-gray-700"
+            className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
           >
             Sign out
           </button>
@@ -61,7 +61,7 @@ export default function AppLayout() {
       </main>
 
       {/* Bottom navigation — mobile only */}
-      <nav className="fixed inset-x-0 bottom-0 flex border-t border-gray-200 bg-white sm:hidden">
+      <nav className="fixed inset-x-0 bottom-0 flex border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 sm:hidden">
         {navLinks.map(({ to, label, end }) => (
           <NavLink
             key={to}
@@ -70,7 +70,7 @@ export default function AppLayout() {
             className={({ isActive }) =>
               [
                 'flex flex-1 flex-col items-center justify-center py-2 text-xs transition-colors',
-                isActive ? 'font-medium text-teal-600' : 'text-gray-500',
+                isActive ? 'font-medium text-teal-600 dark:text-teal-400' : 'text-gray-500 dark:text-gray-400',
               ].join(' ')
             }
           >

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -14,14 +14,14 @@ export default function Modal({ isOpen, onClose, title, children }: ModalProps) 
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-xl bg-white shadow-lg"
+        className="w-full max-w-md rounded-xl bg-white dark:bg-gray-800 shadow-lg"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
-          <h2 className="text-lg font-semibold text-gray-800">{title}</h2>
+        <div className="flex items-center justify-between border-b border-gray-100 dark:border-gray-700 px-6 py-4">
+          <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100">{title}</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600"
+            className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
             aria-label="Close"
           >
             ✕

--- a/client/src/context/ThemeContext.tsx
+++ b/client/src/context/ThemeContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    return (localStorage.getItem('theme') as Theme) ?? 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  function toggleTheme() {
+    setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used inside ThemeProvider');
+  return ctx;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,1 +1,3 @@
 @import "tailwindcss";
+
+@custom-variant dark (.dark &);

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -115,17 +115,17 @@ export default function DashboardPage() {
       {/* Header */}
       <div className="mb-8">
         <p className="text-sm text-gray-400">{formatDate(new Date())}</p>
-        <h1 className="mt-1 text-2xl font-semibold text-gray-800">
+        <h1 className="mt-1 text-2xl font-semibold text-gray-800 dark:text-gray-100">
           {getGreeting()}{name ? `, ${name}` : ''}
         </h1>
       </div>
 
       {/* Streak */}
       <section className="mb-8">
-        <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-gray-400">
+        <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
           This week
         </h2>
-        <div className="inline-flex items-end gap-3 rounded-xl bg-white px-5 py-4 shadow-sm">
+        <div className="inline-flex items-end gap-3 rounded-xl bg-white dark:bg-gray-800 px-5 py-4 shadow-sm">
           <div className="flex gap-2">
             {WEEK_DAYS.map((day, i) => {
               const d = new Date(weekStart);
@@ -138,19 +138,19 @@ export default function DashboardPage() {
                   <div
                     className={`h-3 w-3 rounded-full transition-colors ${
                       isFuture
-                        ? 'bg-gray-100'
+                        ? 'bg-gray-100 dark:bg-gray-700'
                         : isLogged
                           ? 'bg-teal-500'
-                          : 'bg-gray-200'
+                          : 'bg-gray-200 dark:bg-gray-600'
                     }`}
                   />
-                  <span className="text-[10px] text-gray-400">{day}</span>
+                  <span className="text-[10px] text-gray-400 dark:text-gray-500">{day}</span>
                 </div>
               );
             })}
           </div>
-          <p className="ml-2 text-sm text-gray-500">
-            <span className="font-semibold text-gray-700">{loggedDatesThisWeek.size}</span>
+          <p className="ml-2 text-sm text-gray-500 dark:text-gray-400">
+            <span className="font-semibold text-gray-700 dark:text-gray-200">{loggedDatesThisWeek.size}</span>
             {' '}of {daysFromMonday + 1} days logged
           </p>
         </div>
@@ -158,14 +158,14 @@ export default function DashboardPage() {
 
       {/* Today's summary */}
       <section>
-        <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-gray-400">
+        <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
           Today's summary
         </h2>
 
         {isLoading ? (
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
             {summaryCards.map(({ key }) => (
-              <div key={key} className="h-28 animate-pulse rounded-xl bg-gray-100" />
+              <div key={key} className="h-28 animate-pulse rounded-xl bg-gray-100 dark:bg-gray-700" />
             ))}
           </div>
         ) : (
@@ -173,11 +173,11 @@ export default function DashboardPage() {
             {summaryCards.map(({ key, label, color, quickAdd: type, quickAddLabel }) => {
               const count = counts?.[key] ?? 0;
               return (
-                <div key={key} className="flex flex-col rounded-xl bg-white p-5 shadow-sm">
-                  <p className="text-sm text-gray-500">{label}</p>
-                  <p className="mt-1 text-3xl font-semibold text-gray-800">{count}</p>
+                <div key={key} className="flex flex-col rounded-xl bg-white dark:bg-gray-800 p-5 shadow-sm">
+                  <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+                  <p className="mt-1 text-3xl font-semibold text-gray-800 dark:text-gray-100">{count}</p>
                   {count === 0 ? (
-                    <p className="mt-1 text-xs text-gray-400">None logged yet</p>
+                    <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">None logged yet</p>
                   ) : (
                     <p className={`mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
                       {count === 1 ? '1 entry' : `${count} entries`}
@@ -185,7 +185,7 @@ export default function DashboardPage() {
                   )}
                   <button
                     onClick={() => setQuickAdd(type)}
-                    className="mt-3 self-start text-xs font-medium text-teal-600 hover:text-teal-700"
+                    className="mt-3 self-start text-xs font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300"
                   >
                     {quickAddLabel}
                   </button>

--- a/client/src/pages/ForgotPasswordPage.tsx
+++ b/client/src/pages/ForgotPasswordPage.tsx
@@ -32,7 +32,7 @@ export default function ForgotPasswordPage() {
 
   if (submitted) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
         <div className="w-full max-w-sm rounded-xl bg-white p-8 shadow-sm text-center">
           <div className="mb-4 flex justify-center">
             <span className="flex h-12 w-12 items-center justify-center rounded-full bg-teal-100 text-teal-600 text-2xl">
@@ -56,8 +56,8 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-sm rounded-xl bg-white p-8 shadow-sm">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="w-full max-w-sm rounded-xl bg-white dark:bg-gray-800 p-8 shadow-sm">
         <h1 className="mb-2 text-center text-2xl font-semibold text-gray-800">
           Forgot your password?
         </h1>
@@ -77,7 +77,7 @@ export default function ForgotPasswordPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               autoComplete="email"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
             />
           </div>
 

--- a/client/src/pages/HistoryPage.tsx
+++ b/client/src/pages/HistoryPage.tsx
@@ -270,7 +270,7 @@ export default function HistoryPage() {
 
   return (
     <div className="p-8">
-      <h1 className="mb-6 text-2xl font-semibold text-gray-800">History</h1>
+      <h1 className="mb-6 text-2xl font-semibold text-gray-800 dark:text-gray-100">History</h1>
 
       {/* Type filter chips */}
       <div className="mb-6 flex flex-wrap gap-2">
@@ -281,7 +281,7 @@ export default function HistoryPage() {
             className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
               activeTypes.has(type)
                 ? TYPE_COLORS[type]
-                : 'bg-gray-100 text-gray-400 hover:bg-gray-200'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-600'
             }`}
           >
             {label}
@@ -290,7 +290,7 @@ export default function HistoryPage() {
       </div>
 
       {deleteError && (
-        <p role="alert" className="mb-4 rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-600">
+        <p role="alert" className="mb-4 rounded-md bg-rose-50 dark:bg-rose-900/20 px-4 py-3 text-sm text-rose-600 dark:text-rose-400">
           {deleteError}
         </p>
       )}
@@ -298,13 +298,13 @@ export default function HistoryPage() {
       {isLoading ? (
         <div className="space-y-3">
           {[1, 2, 3].map((n) => (
-            <div key={n} className="h-16 animate-pulse rounded-xl bg-gray-100" />
+            <div key={n} className="h-16 animate-pulse rounded-xl bg-gray-100 dark:bg-gray-700" />
           ))}
         </div>
       ) : fetchError ? (
         <p className="text-sm text-rose-600">{fetchError}</p>
       ) : sortedDates.length === 0 ? (
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-400 dark:text-gray-500">
           No entries found. Start logging to see your history here.
         </p>
       ) : (
@@ -314,26 +314,26 @@ export default function HistoryPage() {
             const isExpanded = expandedDays.has(dateKey);
 
             return (
-              <div key={dateKey} className="overflow-hidden rounded-xl bg-white shadow-sm">
+              <div key={dateKey} className="overflow-hidden rounded-xl bg-white dark:bg-gray-800 shadow-sm">
                 {/* Day header — click to collapse / expand */}
                 <button
                   onClick={() => toggleDay(dateKey)}
-                  className="flex w-full items-center justify-between px-5 py-4 text-left hover:bg-gray-50"
+                  className="flex w-full items-center justify-between px-5 py-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700"
                 >
                   <div>
-                    <span className="font-medium text-gray-800">
+                    <span className="font-medium text-gray-800 dark:text-gray-100">
                       {formatDayHeading(dateKey)}
                     </span>
-                    <span className="ml-2 text-sm text-gray-400">
+                    <span className="ml-2 text-sm text-gray-400 dark:text-gray-500">
                       {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
                     </span>
                   </div>
-                  <span className="text-xs text-gray-400">{isExpanded ? '▲' : '▼'}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500">{isExpanded ? '▲' : '▼'}</span>
                 </button>
 
                 {/* Entry rows */}
                 {isExpanded && (
-                  <div className="border-t border-gray-100">
+                  <div className="border-t border-gray-100 dark:border-gray-700">
                     {entries.map((entry) => {
                       const isConfirming =
                         confirmDelete?.id === entry.id && confirmDelete?.type === entry.type;
@@ -341,7 +341,7 @@ export default function HistoryPage() {
                       return (
                         <div
                           key={`${entry.type}-${entry.id}`}
-                          className="flex items-center gap-3 border-b border-gray-50 px-5 py-3 last:border-b-0"
+                          className="flex items-center gap-3 border-b border-gray-50 dark:border-gray-700 px-5 py-3 last:border-b-0"
                         >
                           {/* Type badge */}
                           <span
@@ -351,19 +351,19 @@ export default function HistoryPage() {
                           </span>
 
                           {/* Entry detail text */}
-                          <span className="flex-1 text-sm text-gray-700">
+                          <span className="flex-1 text-sm text-gray-700 dark:text-gray-300">
                             {renderEntryDetail(entry)}
                           </span>
 
                           {/* Timestamp */}
-                          <span className="shrink-0 text-xs text-gray-400">
+                          <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
                             {getEntryTime(entry)}
                           </span>
 
                           {/* Inline delete confirmation or Edit/Delete buttons */}
                           {isConfirming ? (
                             <div className="flex shrink-0 items-center gap-2 text-sm">
-                              <span className="text-gray-500">Delete?</span>
+                              <span className="text-gray-500 dark:text-gray-400">Delete?</span>
                               <button
                                 onClick={() => void handleDelete(entry.type, entry.id)}
                                 className="font-medium text-rose-600 hover:text-rose-700"
@@ -372,7 +372,7 @@ export default function HistoryPage() {
                               </button>
                               <button
                                 onClick={() => setConfirmDelete(null)}
-                                className="text-gray-400 hover:text-gray-600"
+                                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                               >
                                 Cancel
                               </button>
@@ -381,7 +381,7 @@ export default function HistoryPage() {
                             <div className="flex shrink-0 gap-3 text-xs">
                               <button
                                 onClick={() => openEditModal(entry)}
-                                className="font-medium text-teal-600 hover:text-teal-700"
+                                className="font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300"
                               >
                                 Edit
                               </button>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -36,21 +36,21 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-sm rounded-xl bg-white p-8 shadow-sm">
-        <h1 className="mb-6 text-center text-2xl font-semibold text-gray-800">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="w-full max-w-sm rounded-xl bg-white dark:bg-gray-800 p-8 shadow-sm">
+        <h1 className="mb-6 text-center text-2xl font-semibold text-gray-800 dark:text-gray-100">
           Sign in to WellTrack
         </h1>
 
         {passwordReset && (
-          <p role="status" className="mb-4 rounded-md bg-teal-50 px-3 py-2 text-sm text-teal-700">
+          <p role="status" className="mb-4 rounded-md bg-teal-50 dark:bg-teal-900/30 px-3 py-2 text-sm text-teal-700 dark:text-teal-300">
             Password updated. Sign in with your new password.
           </p>
         )}
 
         <form onSubmit={(e) => void handleSubmit(e)} noValidate className="flex flex-col gap-4">
           <div>
-            <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700">
+            <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
               Email
             </label>
             <input
@@ -60,18 +60,18 @@ export default function LoginPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               autoComplete="email"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
             />
           </div>
 
           <div>
             <div className="mb-1 flex items-center justify-between">
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                 Password
               </label>
               <Link
                 to="/forgot-password"
-                className="text-xs font-medium text-teal-600 hover:text-teal-700"
+                className="text-xs font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300"
               >
                 Forgot password?
               </Link>
@@ -83,12 +83,12 @@ export default function LoginPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               autoComplete="current-password"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
             />
           </div>
 
           {error && (
-            <p role="alert" className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">
+            <p role="alert" className="rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-600 dark:text-red-400">
               {error}
             </p>
           )}
@@ -102,9 +102,9 @@ export default function LoginPage() {
           </button>
         </form>
 
-        <p className="mt-6 text-center text-sm text-gray-500">
+        <p className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
           Don&apos;t have an account?{' '}
-          <Link to="/register" className="font-medium text-teal-600 hover:text-teal-700">
+          <Link to="/register" className="font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300">
             Create one
           </Link>
         </p>

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -40,15 +40,15 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-sm rounded-xl bg-white p-8 shadow-sm">
-        <h1 className="mb-6 text-center text-2xl font-semibold text-gray-800">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="w-full max-w-sm rounded-xl bg-white dark:bg-gray-800 p-8 shadow-sm">
+        <h1 className="mb-6 text-center text-2xl font-semibold text-gray-800 dark:text-gray-100">
           Create your account
         </h1>
 
         <form onSubmit={(e) => void handleSubmit(e)} noValidate className="flex flex-col gap-4">
           <div>
-            <label htmlFor="displayName" className="mb-1 block text-sm font-medium text-gray-700">
+            <label htmlFor="displayName" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
               Display name <span className="text-gray-400">(optional)</span>
             </label>
             <input
@@ -57,12 +57,12 @@ export default function RegisterPage() {
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
               autoComplete="name"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
             />
           </div>
 
           <div>
-            <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700">
+            <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
               Email
             </label>
             <input
@@ -72,12 +72,12 @@ export default function RegisterPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               autoComplete="email"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="mb-1 block text-sm font-medium text-gray-700">
+            <label htmlFor="password" className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
               Password
             </label>
             <input
@@ -88,7 +88,7 @@ export default function RegisterPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               autoComplete="new-password"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
             />
             <p className="mt-1 text-xs text-gray-400">Minimum 8 characters</p>
           </div>
@@ -108,7 +108,7 @@ export default function RegisterPage() {
           </button>
         </form>
 
-        <p className="mt-6 text-center text-sm text-gray-500">
+        <p className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
           Already have an account?{' '}
           <Link to="/login" className="font-medium text-teal-600 hover:text-teal-700">
             Sign in

--- a/client/src/pages/ResetPasswordPage.tsx
+++ b/client/src/pages/ResetPasswordPage.tsx
@@ -15,7 +15,7 @@ export default function ResetPasswordPage() {
 
   if (!token) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
         <div className="w-full max-w-sm rounded-xl bg-white p-8 shadow-sm text-center">
           <h1 className="mb-2 text-xl font-semibold text-gray-800">Invalid reset link</h1>
           <p className="mb-6 text-sm text-gray-500">
@@ -58,8 +58,8 @@ export default function ResetPasswordPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-sm rounded-xl bg-white p-8 shadow-sm">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="w-full max-w-sm rounded-xl bg-white dark:bg-gray-800 p-8 shadow-sm">
         <h1 className="mb-2 text-center text-2xl font-semibold text-gray-800">
           Set a new password
         </h1>
@@ -80,7 +80,7 @@ export default function ResetPasswordPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               autoComplete="new-password"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:ring-1 focus:ring-teal-500 focus:outline-none"
             />
             <p className="mt-1 text-xs text-gray-400">Minimum 8 characters</p>
           </div>

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -3,8 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import api from '../services/api';
 import type { ApiError, Habit, Medication, Symptom, UserProfile } from '../types/api';
 import { useAuth } from '../hooks/useAuth';
+import { useTheme } from '../context/ThemeContext';
 
-type Section = 'profile' | 'symptoms' | 'habits' | 'medications' | 'export' | 'account';
+type Section = 'profile' | 'symptoms' | 'habits' | 'medications' | 'export' | 'appearance' | 'account';
 
 const NAV: { key: Section; label: string }[] = [
   { key: 'profile', label: 'Profile' },
@@ -12,6 +13,7 @@ const NAV: { key: Section; label: string }[] = [
   { key: 'habits', label: 'Habits' },
   { key: 'medications', label: 'Medications' },
   { key: 'export', label: 'Export' },
+  { key: 'appearance', label: 'Appearance' },
   { key: 'account', label: 'Account' },
 ];
 
@@ -22,11 +24,11 @@ function apiError(err: unknown): string {
 }
 
 function SectionCard({ children }: { children: React.ReactNode }) {
-  return <div className="rounded-xl bg-white p-6 shadow-sm">{children}</div>;
+  return <div className="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-sm">{children}</div>;
 }
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
-  return <h2 className="mb-5 text-base font-semibold text-gray-800">{children}</h2>;
+  return <h2 className="mb-5 text-base font-semibold text-gray-800 dark:text-gray-100">{children}</h2>;
 }
 
 // ─── Profile ──────────────────────────────────────────────────────────────────
@@ -80,13 +82,13 @@ function ProfileSection() {
     <SectionCard>
       <SectionTitle>Profile</SectionTitle>
       {profile && (
-        <p className="mb-4 text-sm text-gray-500">
-          Account email: <span className="font-medium text-gray-700">{profile.email}</span>
+        <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+          Account email: <span className="font-medium text-gray-700 dark:text-gray-200">{profile.email}</span>
         </p>
       )}
       <form onSubmit={(e) => void handleSave(e)} className="space-y-4">
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="displayName">
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300" htmlFor="displayName">
             Display name
           </label>
           <input
@@ -95,18 +97,18 @@ function ProfileSection() {
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             placeholder="Your name"
-            className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+            className="w-full rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
           />
         </div>
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="timezone">
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300" htmlFor="timezone">
             Timezone
           </label>
           <select
             id="timezone"
             value={timezone}
             onChange={(e) => setTimezone(e.target.value)}
-            className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+            className="w-full rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
           >
             {TIMEZONES.map((tz) => (
               <option key={tz} value={tz}>
@@ -196,10 +198,10 @@ function SymptomsSection() {
       {error && <p role="alert" className="mb-3 text-sm text-rose-600">{error}</p>}
       {isLoading ? (
         <div className="space-y-2">
-          {[1, 2, 3].map((n) => <div key={n} className="h-10 animate-pulse rounded-lg bg-gray-100" />)}
+          {[1, 2, 3].map((n) => <div key={n} className="h-10 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-700" />)}
         </div>
       ) : (
-        <ul className="mb-6 divide-y divide-gray-100">
+        <ul className="mb-6 divide-y divide-gray-100 dark:divide-gray-700">
           {symptoms.map((s) => {
             const isSystem = s.userId === null;
             return (
@@ -218,7 +220,7 @@ function SymptomsSection() {
                     }`}
                   />
                 </button>
-                <span className="flex-1 text-sm text-gray-700">{s.name}</span>
+                <span className="flex-1 text-sm text-gray-700 dark:text-gray-300">{s.name}</span>
                 {s.category && (
                   <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
                     {s.category}
@@ -240,8 +242,8 @@ function SymptomsSection() {
         </ul>
       )}
 
-      <form onSubmit={(e) => void handleAdd(e)} className="border-t border-gray-100 pt-4">
-        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+      <form onSubmit={(e) => void handleAdd(e)} className="border-t border-gray-100 dark:border-gray-700 pt-4">
+        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
           Add custom symptom
         </p>
         <div className="flex gap-2">
@@ -250,7 +252,7 @@ function SymptomsSection() {
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             placeholder="Symptom name"
-            className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+            className="flex-1 rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
           />
           <input
             type="text"
@@ -345,10 +347,10 @@ function HabitsSection() {
       {error && <p role="alert" className="mb-3 text-sm text-rose-600">{error}</p>}
       {isLoading ? (
         <div className="space-y-2">
-          {[1, 2, 3].map((n) => <div key={n} className="h-10 animate-pulse rounded-lg bg-gray-100" />)}
+          {[1, 2, 3].map((n) => <div key={n} className="h-10 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-700" />)}
         </div>
       ) : (
-        <ul className="mb-6 divide-y divide-gray-100">
+        <ul className="mb-6 divide-y divide-gray-100 dark:divide-gray-700">
           {habits.map((h) => {
             const isSystem = h.userId === null;
             return (
@@ -367,7 +369,7 @@ function HabitsSection() {
                     }`}
                   />
                 </button>
-                <span className="flex-1 text-sm text-gray-700">{h.name}</span>
+                <span className="flex-1 text-sm text-gray-700 dark:text-gray-300">{h.name}</span>
                 <span className="rounded-full bg-teal-50 px-2 py-0.5 text-xs text-teal-700">
                   {TYPE_LABELS[h.trackingType]}
                 </span>
@@ -388,8 +390,8 @@ function HabitsSection() {
         </ul>
       )}
 
-      <form onSubmit={(e) => void handleAdd(e)} className="border-t border-gray-100 pt-4">
-        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+      <form onSubmit={(e) => void handleAdd(e)} className="border-t border-gray-100 dark:border-gray-700 pt-4">
+        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
           Add custom habit
         </p>
         <div className="flex flex-wrap gap-2">
@@ -398,12 +400,12 @@ function HabitsSection() {
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             placeholder="Habit name"
-            className="min-w-32 flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+            className="min-w-32 flex-1 rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
           />
           <select
             value={newType}
             onChange={(e) => setNewType(e.target.value as typeof newType)}
-            className="rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+            className="rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
           >
             <option value="boolean">Yes/No</option>
             <option value="numeric">Number</option>
@@ -538,13 +540,13 @@ function MedicationsSection() {
       {isLoading ? (
         <div className="space-y-2">
           {[1, 2, 3].map((n) => (
-            <div key={n} className="h-12 animate-pulse rounded-lg bg-gray-100" />
+            <div key={n} className="h-12 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-700" />
           ))}
         </div>
       ) : medications.length === 0 ? (
         <p className="mb-4 text-sm text-gray-400">No medications added yet.</p>
       ) : (
-        <ul className="mb-6 divide-y divide-gray-100">
+        <ul className="mb-6 divide-y divide-gray-100 dark:divide-gray-700">
           {medications.map((m) => (
             <li key={m.id} className="py-3">
               {editId === m.id ? (
@@ -555,21 +557,21 @@ function MedicationsSection() {
                       value={editName}
                       onChange={(e) => setEditName(e.target.value)}
                       placeholder="Name"
-                      className="flex-1 rounded-lg border border-gray-200 px-3 py-1.5 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+                      className="flex-1 rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-1.5 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
                     />
                     <input
                       type="text"
                       value={editDosage}
                       onChange={(e) => setEditDosage(e.target.value)}
                       placeholder="Dosage"
-                      className="w-28 rounded-lg border border-gray-200 px-3 py-1.5 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+                      className="w-28 rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-1.5 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
                     />
                     <input
                       type="text"
                       value={editFrequency}
                       onChange={(e) => setEditFrequency(e.target.value)}
                       placeholder="Frequency"
-                      className="w-28 rounded-lg border border-gray-200 px-3 py-1.5 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+                      className="w-28 rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-1.5 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
                     />
                   </div>
                   {editError && <p className="text-xs text-rose-600">{editError}</p>}
@@ -583,7 +585,7 @@ function MedicationsSection() {
                     </button>
                     <button
                       onClick={() => setEditId(null)}
-                      className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs text-gray-500 hover:bg-gray-50"
+                      className="rounded-lg border border-gray-200 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-700 px-3 py-1.5 text-xs text-gray-500 hover:bg-gray-50"
                     >
                       Cancel
                     </button>
@@ -604,7 +606,7 @@ function MedicationsSection() {
                     />
                   </button>
                   <div className="flex-1">
-                    <span className="text-sm text-gray-700">{m.name}</span>
+                    <span className="text-sm text-gray-700 dark:text-gray-300">{m.name}</span>
                     {(m.dosage || m.frequency) && (
                       <span className="ml-2 text-xs text-gray-400">
                         {[m.dosage, m.frequency].filter(Boolean).join(' · ')}
@@ -655,8 +657,8 @@ function MedicationsSection() {
         </ul>
       )}
 
-      <form onSubmit={(e) => void handleAdd(e)} className="border-t border-gray-100 pt-4">
-        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+      <form onSubmit={(e) => void handleAdd(e)} className="border-t border-gray-100 dark:border-gray-700 pt-4">
+        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
           Add medication
         </p>
         <div className="flex flex-wrap gap-2">
@@ -665,7 +667,7 @@ function MedicationsSection() {
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             placeholder="Medication name"
-            className="min-w-32 flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+            className="min-w-32 flex-1 rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
           />
           <input
             type="text"
@@ -733,13 +735,13 @@ function ExportSection() {
   return (
     <SectionCard>
       <SectionTitle>Export Data</SectionTitle>
-      <p className="mb-5 text-sm text-gray-500">
+      <p className="mb-5 text-sm text-gray-500 dark:text-gray-400">
         Download all your logs as a CSV file. Leave the date fields blank to export everything.
       </p>
       <form onSubmit={(e) => void handleDownload(e)} className="space-y-4">
         <div className="flex gap-4">
           <div className="flex-1">
-            <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="exportStart">
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300" htmlFor="exportStart">
               From
             </label>
             <input
@@ -747,11 +749,11 @@ function ExportSection() {
               type="date"
               value={startDate}
               onChange={(e) => setStartDate(e.target.value)}
-              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+              className="w-full rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
             />
           </div>
           <div className="flex-1">
-            <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="exportEnd">
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300" htmlFor="exportEnd">
               To
             </label>
             <input
@@ -759,7 +761,7 @@ function ExportSection() {
               type="date"
               value={endDate}
               onChange={(e) => setEndDate(e.target.value)}
-              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
+              className="w-full rounded-lg border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm outline-none focus:border-teal-500 focus:ring-1 focus:ring-teal-500"
             />
           </div>
         </div>
@@ -772,6 +774,41 @@ function ExportSection() {
           {isDownloading ? 'Preparing…' : 'Download CSV'}
         </button>
       </form>
+    </SectionCard>
+  );
+}
+
+// ─── Appearance ───────────────────────────────────────────────────────────────
+
+function AppearanceSection() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <SectionCard>
+      <SectionTitle>Appearance</SectionTitle>
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Dark mode</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500">
+            Switch between light and dark themes. Your preference is saved automatically.
+          </p>
+        </div>
+        <button
+          role="switch"
+          aria-checked={isDark}
+          onClick={toggleTheme}
+          className={`relative h-6 w-11 flex-shrink-0 rounded-full transition-colors ${
+            isDark ? 'bg-teal-500' : 'bg-gray-200'
+          }`}
+        >
+          <span
+            className={`absolute top-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+              isDark ? 'translate-x-6' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
     </SectionCard>
   );
 }
@@ -848,18 +885,18 @@ export default function SettingsPage() {
 
   return (
     <div className="p-8">
-      <h1 className="mb-6 text-2xl font-semibold text-gray-800">Settings</h1>
+      <h1 className="mb-6 text-2xl font-semibold text-gray-800 dark:text-gray-100">Settings</h1>
 
       {/* Tab nav */}
-      <nav className="mb-6 flex flex-wrap gap-1 border-b border-gray-200">
+      <nav className="mb-6 flex flex-wrap gap-1 border-b border-gray-200 dark:border-gray-700">
         {NAV.map(({ key, label }) => (
           <button
             key={key}
             onClick={() => setActive(key)}
             className={`rounded-t-lg px-4 py-2 text-sm font-medium transition-colors ${
               active === key
-                ? 'border-b-2 border-teal-600 text-teal-700'
-                : 'text-gray-500 hover:text-gray-700'
+                ? 'border-b-2 border-teal-600 text-teal-700 dark:text-teal-400'
+                : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
             }`}
           >
             {label}
@@ -872,6 +909,7 @@ export default function SettingsPage() {
       {active === 'habits' && <HabitsSection />}
       {active === 'medications' && <MedicationsSection />}
       {active === 'export' && <ExportSection />}
+      {active === 'appearance' && <AppearanceSection />}
       {active === 'account' && <AccountSection />}
     </div>
   );

--- a/client/src/pages/TrendsPage.tsx
+++ b/client/src/pages/TrendsPage.tsx
@@ -42,10 +42,10 @@ function activityLevel(count: number): 0 | 1 | 2 | 3 {
 }
 
 const HEAT_COLORS: Record<0 | 1 | 2 | 3, string> = {
-  0: 'bg-gray-100',
-  1: 'bg-teal-200',
-  2: 'bg-teal-400',
-  3: 'bg-teal-600',
+  0: 'bg-gray-100 dark:bg-gray-700',
+  1: 'bg-teal-200 dark:bg-teal-800',
+  2: 'bg-teal-400 dark:bg-teal-600',
+  3: 'bg-teal-600 dark:bg-teal-400',
 };
 
 function formatAxisDate(date: string, days: Days): string {
@@ -215,18 +215,18 @@ export default function TrendsPage() {
   return (
     <div className="space-y-8 p-8">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-gray-800">Trends</h1>
+        <h1 className="text-2xl font-semibold text-gray-800 dark:text-gray-100">Trends</h1>
 
         {/* Date range selector */}
-        <div className="flex gap-1 rounded-lg bg-gray-100 p-1">
+        <div className="flex gap-1 rounded-lg bg-gray-100 dark:bg-gray-700 p-1">
           {DAY_OPTIONS.map((d) => (
             <button
               key={d}
               onClick={() => setDays(d)}
               className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
                 days === d
-                  ? 'bg-white text-gray-800 shadow-sm'
-                  : 'text-gray-500 hover:text-gray-700'
+                  ? 'bg-white dark:bg-gray-600 text-gray-800 dark:text-gray-100 shadow-sm'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
               }`}
             >
               {d}d
@@ -236,22 +236,22 @@ export default function TrendsPage() {
       </div>
 
       {fetchError && (
-        <p role="alert" className="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-600">
+        <p role="alert" className="rounded-md bg-rose-50 dark:bg-rose-900/20 px-4 py-3 text-sm text-rose-600 dark:text-rose-400">
           {fetchError}
         </p>
       )}
 
       {/* ── Mood / Energy / Stress chart ── */}
-      <section className="rounded-xl bg-white p-6 shadow-sm">
-        <h2 className="mb-4 text-base font-semibold text-gray-700">Mood, Energy & Stress</h2>
+      <section className="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-sm">
+        <h2 className="mb-4 text-base font-semibold text-gray-700 dark:text-gray-200">Mood, Energy & Stress</h2>
         {moodLoading ? (
-          <div className="h-48 animate-pulse rounded-lg bg-gray-100" />
+          <div className="h-48 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-700" />
         ) : moodChartData.length === 0 ? (
-          <p className="text-sm text-gray-400">No mood data logged in this period.</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500">No mood data logged in this period.</p>
         ) : (
           <ResponsiveContainer width="100%" height={240}>
             <LineChart data={moodChartData} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" />
+              <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
               <XAxis
                 dataKey="date"
                 tickFormatter={(v: string) => formatAxisDate(v, days)}
@@ -269,7 +269,7 @@ export default function TrendsPage() {
               />
               <Tooltip
                 labelFormatter={(v) => formatTooltipDate(String(v))}
-                contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', fontSize: 12 }}
+                contentStyle={{ borderRadius: '8px', border: '1px solid #374151', background: '#1f2937', color: '#f3f4f6', fontSize: 12 }}
               />
               <Legend iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 12 }} />
               {MOOD_LINES.map((l) => (
@@ -291,14 +291,14 @@ export default function TrendsPage() {
       </section>
 
       {/* ── Symptom severity chart ── */}
-      <section className="rounded-xl bg-white p-6 shadow-sm">
-        <h2 className="mb-4 text-base font-semibold text-gray-700">Symptom Severity</h2>
+      <section className="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-sm">
+        <h2 className="mb-4 text-base font-semibold text-gray-700 dark:text-gray-200">Symptom Severity</h2>
 
         {/* Symptom selector */}
         {symptomsLoading ? (
           <div className="mb-4 flex gap-2">
             {[1, 2, 3].map((n) => (
-              <div key={n} className="h-7 w-24 animate-pulse rounded-full bg-gray-100" />
+              <div key={n} className="h-7 w-24 animate-pulse rounded-full bg-gray-100 dark:bg-gray-700" />
             ))}
           </div>
         ) : (
@@ -309,8 +309,8 @@ export default function TrendsPage() {
                 onClick={() => toggleSymptom(s.id)}
                 className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
                   selectedSymptomIds.has(s.id)
-                    ? 'bg-violet-100 text-violet-700'
-                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                    ? 'bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
                 }`}
               >
                 {s.name}
@@ -320,13 +320,13 @@ export default function TrendsPage() {
         )}
 
         {selectedSymptomIds.size === 0 ? (
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-400 dark:text-gray-500">
             Select one or more symptoms above to chart their severity over time.
           </p>
         ) : symptomTrendLoading ? (
-          <div className="h-48 animate-pulse rounded-lg bg-gray-100" />
+          <div className="h-48 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-700" />
         ) : symptomChartData.length === 0 ? (
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-400 dark:text-gray-500">
             No data logged for the selected symptoms in this period.
           </p>
         ) : (
@@ -335,7 +335,7 @@ export default function TrendsPage() {
               data={symptomChartData}
               margin={{ top: 4, right: 16, left: 0, bottom: 4 }}
             >
-              <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" />
+              <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
               <XAxis
                 dataKey="date"
                 tickFormatter={(v: string) => formatAxisDate(v, days)}
@@ -353,7 +353,7 @@ export default function TrendsPage() {
               />
               <Tooltip
                 labelFormatter={(v) => formatTooltipDate(String(v))}
-                contentStyle={{ borderRadius: '8px', border: '1px solid #e5e7eb', fontSize: 12 }}
+                contentStyle={{ borderRadius: '8px', border: '1px solid #374151', background: '#1f2937', color: '#f3f4f6', fontSize: 12 }}
               />
               <Legend iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 12 }} />
               {[...selectedSymptomIds].map((id, i) => {
@@ -378,14 +378,14 @@ export default function TrendsPage() {
       </section>
 
       {/* ── Activity calendar heatmap ── */}
-      <section className="rounded-xl bg-white p-6 shadow-sm">
-        <h2 className="mb-1 text-base font-semibold text-gray-700">Logging Activity</h2>
-        <p className="mb-4 text-xs text-gray-400">
+      <section className="rounded-xl bg-white dark:bg-gray-800 p-6 shadow-sm">
+        <h2 className="mb-1 text-base font-semibold text-gray-700 dark:text-gray-200">Logging Activity</h2>
+        <p className="mb-4 text-xs text-gray-400 dark:text-gray-500">
           Total entries logged per day across all categories
         </p>
 
         {activityLoading ? (
-          <div className="h-20 animate-pulse rounded-lg bg-gray-100" />
+          <div className="h-20 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-700" />
         ) : (
           <>
             {/* Heatmap grid — one square per day */}
@@ -409,7 +409,7 @@ export default function TrendsPage() {
             </div>
 
             {/* Legend */}
-            <div className="mt-3 flex items-center gap-2 text-xs text-gray-400">
+            <div className="mt-3 flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
               <span>Less</span>
               {([0, 1, 2, 3] as const).map((l) => (
                 <div key={l} className={`h-4 w-4 rounded-sm ${HEAT_COLORS[l]}`} />

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -225,7 +225,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 ### Frontend Features
 
 - [x] Add 60-day, 120-day, and 365-day options to the trends date range selector (update frontend selector and confirm backend accepts new `days` values)
-- [ ] Dark mode toggle — add a light/dark theme switch to the Settings page; persist preference in `localStorage`; apply via Tailwind's `darkMode: 'class'` config
+- [x] Dark mode toggle — add a light/dark theme switch to the Settings page; persist preference in `localStorage`; apply via Tailwind's `darkMode: 'class'` config
 - [ ] Correlation chart — add a second metric overlay to the Trends chart so users can compare two metrics (e.g., mood vs. energy) on the same axis
 - [ ] Help page — add a `/help` route with FAQs and how-to guides for logging, viewing trends, and exporting data
 - [ ] Contact page — add a `/contact` route with a support mailto link and links to relevant help resources


### PR DESCRIPTION
## Type
Task

## Summary
- Added `ThemeContext` (`client/src/context/ThemeContext.tsx`) with `localStorage` persistence; toggling applies/removes the `.dark` class on `<html>`
- Configured Tailwind v4 class-based dark mode by adding `@custom-variant dark (.dark &);` to `index.css`
- Added an **Appearance** tab to SettingsPage (`Settings > Appearance`) with a toggle switch for light/dark mode
- Applied `dark:` utility classes throughout the entire app:
  - `AppLayout` (sidebar, bottom nav)
  - All protected pages: Dashboard, History, Trends, Settings
  - All public auth pages: Login, Register, ForgotPassword, ResetPassword
  - `Modal` shared component (all log modals pick this up automatically)

## Testing Checklist
- [ ] Navigate to `Settings > Appearance` and toggle dark mode on — the app switches to a dark theme
- [ ] Refresh the page — the dark theme persists (loaded from `localStorage`)
- [ ] Toggle back to light — the app returns to light theme and persists on refresh
- [ ] Verify Dashboard, History, Trends, Settings, and modals all look correct in dark mode
- [ ] Verify auth pages (Login, Register) respect dark mode if set before logout
- [ ] `npm run build` in `client/` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)