### PR TITLE
Promote backlog items to Phase 5 task list

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -15,9 +15,7 @@ This file is a parking lot for features and improvements that aren't yet schedul
 - [ ] Add pronouns field to profile
 - [ ] Add phone number field to profile
 - [ ] Profile picture upload (avatar)
-- [ ] Allow user to change their email address
 - [ ] Email verification — send a confirmation link; show a green verified badge on the profile once confirmed
-- [ ] Show last login date/time on the profile page
 - [ ] Two-factor authentication (TOTP / authenticator app)
 - [ ] Account deletion with full data erasure (GDPR right-to-erasure)
 
@@ -26,34 +24,15 @@ This file is a parking lot for features and improvements that aren't yet schedul
 - [ ] Printable / shareable summary report for sharing with a healthcare provider
 - [ ] Customizable dashboard — let users pin/unpin widgets and reorder cards
 
-## Notifications & Reminders
-
-- [ ] Daily logging reminder (email or push notification)
-- [ ] Medication reminder alerts
-- [ ] Streak milestone celebrations / badges (e.g., 7-day, 30-day streak)
-- [ ] Weekly wellness summary email digest
-
-## Data & Integrations
-
-- [ ] PDF export of logs and trend charts
-- [ ] Bulk CSV import of historical data
-- [ ] Apple Health / Google Fit integration (read activity and sleep data)
-- [ ] Wearable device sync (Fitbit, Garmin)
-
 ## App Experience & Support
 
-- [ ] Help page — FAQs and how-to guides
-- [ ] Contact us page — support form or mailto link
 - [ ] In-app link to API documentation (e.g., Swagger/OpenAPI viewer)
-- [ ] Dark mode / light-dark theme toggle
 - [ ] Progressive Web App (PWA) — installable on mobile home screen, basic offline caching
 - [ ] Multi-language / i18n support
 
 ## Platform & Infrastructure
 
 - [ ] Admin dashboard — aggregate usage stats (no PII) for monitoring platform health
-- [ ] Per-user rate limiting hardening (beyond global express-rate-limit)
-- [ ] Audit log — record sensitive account events (password change, email change, new-device login)
 
 ## Documentation
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -240,3 +240,16 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 ### Export
 
 - [x] PDF export — add `GET /api/export/pdf` endpoint using `pdfkit`; include log summaries and trend data; add a "Download PDF" button to the Settings > Export section
+
+### Notifications & Reminders
+
+- [ ] Daily logging reminder — send a daily email (or push notification) prompting the user to log if they haven't yet that day
+- [ ] Medication reminder alerts — send reminders for scheduled medications based on frequency
+- [ ] Streak milestone celebrations / badges — detect 7-day, 30-day streak milestones and surface a congratulatory message or badge in the UI
+- [ ] Weekly wellness summary email digest — send a weekly email with a summary of the user's logged activity and trends
+
+### Data & Integrations
+
+- [ ] Bulk CSV import — accept a CSV upload to backfill historical log data for any log type
+- [ ] Apple Health / Google Fit integration — read activity and sleep data from Apple Health or Google Fit and surface it alongside user logs
+- [ ] Wearable device sync — sync data from Fitbit or Garmin devices into the relevant log types


### PR DESCRIPTION
## Summary

- Removed 8 already-completed items from `BACKLOG.md` that had been implemented as part of Phase 5 (email change, last login, PDF export, help page, contact page, dark mode, rate limiting, audit log)
- Added **Notifications & Reminders** section to Phase 5 in `tasks.md` with 4 new tasks (daily reminder, medication alerts, streak milestones, weekly digest)
- Added **Data & Integrations** section to Phase 5 in `tasks.md` with 3 new tasks (bulk CSV import, Apple Health/Google Fit, wearable device sync)

## Type

`Documentation`

## Testing checklist

- [ ] Verify `BACKLOG.md` no longer contains items that are already in `tasks.md`
- [ ] Verify new tasks in `tasks.md` are unchecked and have clear descriptions