### PR TITLE
fix: dark mode contrast in log modals

### DIFF
--- a/client/src/components/LogHabitModal.tsx
+++ b/client/src/components/LogHabitModal.tsx
@@ -114,21 +114,21 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
     <Modal isOpen={isOpen} onClose={onClose} title={log ? 'Edit Habit Log' : 'Log Habit'}>
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
-          <p role="alert" className="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-600">
+          <p role="alert" className="rounded-md bg-rose-50 dark:bg-rose-900/30 px-4 py-3 text-sm text-rose-600 dark:text-rose-400">
             {error}
           </p>
         )}
 
         {noHabits && (
-          <p className="rounded-md bg-amber-50 px-4 py-3 text-sm text-amber-700">
+          <p className="rounded-md bg-amber-50 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
             No active habits found. Add one in Settings first.
           </p>
         )}
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">Habit</label>
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Habit</label>
           {loadingHabits ? (
-            <div className="h-9 animate-pulse rounded-md bg-gray-100" />
+            <div className="h-9 animate-pulse rounded-md bg-gray-100 dark:bg-gray-700" />
           ) : (
             <select
               value={habitId}
@@ -141,7 +141,7 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
               }}
               required
               disabled={noHabits}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500 disabled:bg-gray-50"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500 disabled:bg-gray-50 dark:disabled:bg-gray-800"
             >
               <option value="">Select a habit…</option>
               {habits.map((h) => (
@@ -156,7 +156,7 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
         {/* Adaptive value input based on tracking_type */}
         {selectedHabit?.trackingType === 'boolean' && (
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
+            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
               Did you do it?
             </label>
             <div className="flex gap-3">
@@ -165,8 +165,8 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
                 onClick={() => setValueBoolean(true)}
                 className={`flex-1 rounded-md border py-2 text-sm font-medium transition-colors ${
                   valueBoolean
-                    ? 'border-teal-500 bg-teal-50 text-teal-700'
-                    : 'border-gray-200 text-gray-500 hover:border-teal-300'
+                    ? 'border-teal-500 bg-teal-50 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300'
+                    : 'border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-teal-300'
                 }`}
               >
                 Yes
@@ -176,8 +176,8 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
                 onClick={() => setValueBoolean(false)}
                 className={`flex-1 rounded-md border py-2 text-sm font-medium transition-colors ${
                   !valueBoolean
-                    ? 'border-rose-400 bg-rose-50 text-rose-700'
-                    : 'border-gray-200 text-gray-500 hover:border-rose-300'
+                    ? 'border-rose-400 bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300'
+                    : 'border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-rose-300'
                 }`}
               >
                 No
@@ -188,7 +188,7 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
 
         {selectedHabit?.trackingType === 'numeric' && (
           <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700">
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
               Amount{selectedHabit.unit ? ` (${selectedHabit.unit})` : ''}
             </label>
             <input
@@ -201,14 +201,14 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
               }
               placeholder="Enter amount…"
               required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
             />
           </div>
         )}
 
         {selectedHabit?.trackingType === 'duration' && (
           <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700">
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
               Duration (minutes)
             </label>
             <input
@@ -221,24 +221,24 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
               }
               placeholder="Enter minutes…"
               required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
             />
           </div>
         )}
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">Date &amp; time</label>
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Date &amp; time</label>
           <input
             type="datetime-local"
             value={loggedAt}
             max={toLocalDateTimeString(new Date())}
             onChange={(e) => setLoggedAt(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
           />
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
             Notes (optional)
           </label>
           <textarea
@@ -246,7 +246,7 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
             onChange={(e) => setNotes(e.target.value)}
             rows={3}
             placeholder="Any additional notes…"
-            className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+            className="w-full resize-none rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
           />
         </div>
 
@@ -254,7 +254,7 @@ export default function LogHabitModal({ isOpen, onClose, onSuccess, log }: Props
           <button
             type="button"
             onClick={onClose}
-            className="w-full rounded-md px-4 py-2 text-sm text-gray-600 hover:text-gray-800 sm:w-auto"
+            className="w-full rounded-md px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 sm:w-auto"
           >
             Cancel
           </button>

--- a/client/src/components/LogMedicationModal.tsx
+++ b/client/src/components/LogMedicationModal.tsx
@@ -103,28 +103,28 @@ export default function LogMedicationModal({ isOpen, onClose, onSuccess, log }: 
     >
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
-          <p role="alert" className="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-600">
+          <p role="alert" className="rounded-md bg-rose-50 dark:bg-rose-900/30 px-4 py-3 text-sm text-rose-600 dark:text-rose-400">
             {error}
           </p>
         )}
 
         {noMeds && (
-          <p className="rounded-md bg-amber-50 px-4 py-3 text-sm text-amber-700">
+          <p className="rounded-md bg-amber-50 dark:bg-amber-900/30 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
             No active medications found. Add one in Settings first.
           </p>
         )}
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">Medication</label>
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Medication</label>
           {loadingMeds ? (
-            <div className="h-9 animate-pulse rounded-md bg-gray-100" />
+            <div className="h-9 animate-pulse rounded-md bg-gray-100 dark:bg-gray-700" />
           ) : (
             <select
               value={medicationId}
               onChange={(e) => setMedicationId(e.target.value)}
               required
               disabled={noMeds}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500 disabled:bg-gray-50"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500 disabled:bg-gray-50 dark:disabled:bg-gray-800"
             >
               <option value="">Select a medication…</option>
               {medications.map((m) => (
@@ -138,15 +138,15 @@ export default function LogMedicationModal({ isOpen, onClose, onSuccess, log }: 
         </div>
 
         <div>
-          <label className="mb-2 block text-sm font-medium text-gray-700">Did you take it?</label>
+          <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">Did you take it?</label>
           <div className="flex gap-3">
             <button
               type="button"
               onClick={() => setTaken(true)}
               className={`flex-1 rounded-md border py-2 text-sm font-medium transition-colors ${
                 taken
-                  ? 'border-teal-500 bg-teal-50 text-teal-700'
-                  : 'border-gray-200 text-gray-500 hover:border-teal-300'
+                  ? 'border-teal-500 bg-teal-50 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300'
+                  : 'border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-teal-300'
               }`}
             >
               Yes — taken
@@ -156,8 +156,8 @@ export default function LogMedicationModal({ isOpen, onClose, onSuccess, log }: 
               onClick={() => setTaken(false)}
               className={`flex-1 rounded-md border py-2 text-sm font-medium transition-colors ${
                 !taken
-                  ? 'border-rose-400 bg-rose-50 text-rose-700'
-                  : 'border-gray-200 text-gray-500 hover:border-rose-300'
+                  ? 'border-rose-400 bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300'
+                  : 'border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-rose-300'
               }`}
             >
               No — skipped
@@ -167,19 +167,19 @@ export default function LogMedicationModal({ isOpen, onClose, onSuccess, log }: 
 
         {taken && (
           <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700">Taken at</label>
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Taken at</label>
             <input
               type="datetime-local"
               value={takenAt}
               max={toLocalDateTimeString(new Date())}
               onChange={(e) => setTakenAt(e.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
             />
           </div>
         )}
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
             Notes (optional)
           </label>
           <textarea
@@ -187,7 +187,7 @@ export default function LogMedicationModal({ isOpen, onClose, onSuccess, log }: 
             onChange={(e) => setNotes(e.target.value)}
             rows={3}
             placeholder="Any additional notes…"
-            className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+            className="w-full resize-none rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
           />
         </div>
 
@@ -195,7 +195,7 @@ export default function LogMedicationModal({ isOpen, onClose, onSuccess, log }: 
           <button
             type="button"
             onClick={onClose}
-            className="w-full rounded-md px-4 py-2 text-sm text-gray-600 hover:text-gray-800 sm:w-auto"
+            className="w-full rounded-md px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 sm:w-auto"
           >
             Cancel
           </button>

--- a/client/src/components/LogMoodModal.tsx
+++ b/client/src/components/LogMoodModal.tsx
@@ -29,7 +29,7 @@ function ScoreSelector({
 }) {
   return (
     <div>
-      <label className="mb-1.5 block text-sm font-medium text-gray-700">{label}</label>
+      <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">{label}</label>
       <div className="flex gap-2">
         {[1, 2, 3, 4, 5].map((n) => (
           <button
@@ -38,8 +38,8 @@ function ScoreSelector({
             onClick={() => onChange(n)}
             className={`flex-1 rounded-md border py-2 text-sm font-medium transition-colors ${
               value === n
-                ? 'border-teal-500 bg-teal-50 text-teal-700'
-                : 'border-gray-200 text-gray-500 hover:border-teal-300 hover:text-teal-600'
+                ? 'border-teal-500 bg-teal-50 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300'
+                : 'border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-teal-300 hover:text-teal-600'
             }`}
           >
             {n}
@@ -47,7 +47,7 @@ function ScoreSelector({
         ))}
       </div>
       {value !== null && (
-        <p className="mt-1 text-xs text-gray-400">{MOOD_LABELS[value]}</p>
+        <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">{MOOD_LABELS[value]}</p>
       )}
     </div>
   );
@@ -116,7 +116,7 @@ export default function LogMoodModal({ isOpen, onClose, onSuccess, log }: Props)
     <Modal isOpen={isOpen} onClose={onClose} title={log ? 'Edit Mood Log' : 'Log Mood'}>
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
-          <p role="alert" className="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-600">
+          <p role="alert" className="rounded-md bg-rose-50 dark:bg-rose-900/30 px-4 py-3 text-sm text-rose-600 dark:text-rose-400">
             {error}
           </p>
         )}
@@ -134,18 +134,18 @@ export default function LogMoodModal({ isOpen, onClose, onSuccess, log }: Props)
         />
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">Date &amp; time</label>
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Date &amp; time</label>
           <input
             type="datetime-local"
             value={loggedAt}
             max={toLocalDateTimeString(new Date())}
             onChange={(e) => setLoggedAt(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
           />
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
             Notes (optional)
           </label>
           <textarea
@@ -153,7 +153,7 @@ export default function LogMoodModal({ isOpen, onClose, onSuccess, log }: Props)
             onChange={(e) => setNotes(e.target.value)}
             rows={3}
             placeholder="How are you feeling?"
-            className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+            className="w-full resize-none rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
           />
         </div>
 
@@ -161,7 +161,7 @@ export default function LogMoodModal({ isOpen, onClose, onSuccess, log }: Props)
           <button
             type="button"
             onClick={onClose}
-            className="w-full rounded-md px-4 py-2 text-sm text-gray-600 hover:text-gray-800 sm:w-auto"
+            className="w-full rounded-md px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 sm:w-auto"
           >
             Cancel
           </button>

--- a/client/src/components/LogSymptomModal.tsx
+++ b/client/src/components/LogSymptomModal.tsx
@@ -92,21 +92,21 @@ export default function LogSymptomModal({ isOpen, onClose, onSuccess, log }: Pro
     <Modal isOpen={isOpen} onClose={onClose} title={log ? 'Edit Symptom Log' : 'Log Symptom'}>
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
-          <p role="alert" className="rounded-md bg-rose-50 px-4 py-3 text-sm text-rose-600">
+          <p role="alert" className="rounded-md bg-rose-50 dark:bg-rose-900/30 px-4 py-3 text-sm text-rose-600 dark:text-rose-400">
             {error}
           </p>
         )}
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">Symptom</label>
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Symptom</label>
           {loadingSymptoms ? (
-            <div className="h-9 animate-pulse rounded-md bg-gray-100" />
+            <div className="h-9 animate-pulse rounded-md bg-gray-100 dark:bg-gray-700" />
           ) : (
             <select
               value={symptomId}
               onChange={(e) => setSymptomId(e.target.value)}
               required
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
             >
               <option value="">Select a symptom…</option>
               {symptoms.map((s) => (
@@ -119,9 +119,9 @@ export default function LogSymptomModal({ isOpen, onClose, onSuccess, log }: Pro
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
             Severity:{' '}
-            <span className="font-semibold text-teal-600">{severity}</span> / 10
+            <span className="font-semibold text-teal-600 dark:text-teal-400">{severity}</span> / 10
           </label>
           <input
             type="range"
@@ -131,25 +131,25 @@ export default function LogSymptomModal({ isOpen, onClose, onSuccess, log }: Pro
             onChange={(e) => setSeverity(Number(e.target.value))}
             className="w-full accent-teal-500"
           />
-          <div className="flex justify-between text-xs text-gray-400">
+          <div className="flex justify-between text-xs text-gray-400 dark:text-gray-500">
             <span>1 – Mild</span>
             <span>10 – Severe</span>
           </div>
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">Date &amp; time</label>
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Date &amp; time</label>
           <input
             type="datetime-local"
             value={loggedAt}
             max={toLocalDateTimeString(new Date())}
             onChange={(e) => setLoggedAt(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
           />
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">
+          <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
             Notes (optional)
           </label>
           <textarea
@@ -157,7 +157,7 @@ export default function LogSymptomModal({ isOpen, onClose, onSuccess, log }: Pro
             onChange={(e) => setNotes(e.target.value)}
             rows={3}
             placeholder="Any additional details…"
-            className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+            className="w-full resize-none rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
           />
         </div>
 
@@ -165,7 +165,7 @@ export default function LogSymptomModal({ isOpen, onClose, onSuccess, log }: Pro
           <button
             type="button"
             onClick={onClose}
-            className="w-full rounded-md px-4 py-2 text-sm text-gray-600 hover:text-gray-800 sm:w-auto"
+            className="w-full rounded-md px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 sm:w-auto"
           >
             Cancel
           </button>


### PR DESCRIPTION
## Summary
- Added `dark:` Tailwind variants to all form elements (labels, inputs, selects, textareas, toggle buttons, error/warning banners) in `LogSymptomModal`, `LogMoodModal`, `LogHabitModal`, and `LogMedicationModal`
- The `Modal` wrapper already had `dark:bg-gray-800` but the inner form content had no dark mode styles

**Type:** Bug Fix  
Closes #99

## Test plan
- [ ] Enable dark mode via Settings > Appearance
- [ ] Open each log modal (Symptom, Mood, Habit, Medication) from the Dashboard
- [ ] Verify labels, inputs, selects, and textareas are all readable in dark mode
- [ ] Verify toggle buttons (Yes/No, Taken/Skipped) have correct dark mode contrast
- [ ] Verify error/warning banners display correctly in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)