### PR TITLE
feat: streak milestone badges (7-day and 30-day)

### DIFF
--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -118,6 +118,10 @@ export interface ActivityPoint {
   count: number;
 }
 
+export interface StreakInfo {
+  currentStreak: number;
+}
+
 // Import
 export interface ImportResult {
   imported: {

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -245,7 +245,7 @@ Checkbox list of tasks organized by phase. Stack: React + TypeScript + Tailwind 
 
 - [ ] Daily logging reminder — send a daily email (or push notification) prompting the user to log if they haven't yet that day
 - [ ] Medication reminder alerts — send reminders for scheduled medications based on frequency
-- [ ] Streak milestone celebrations / badges — detect 7-day, 30-day streak milestones and surface a congratulatory message or badge in the UI
+- [x] Streak milestone celebrations / badges — detect 7-day, 30-day streak milestones and surface a congratulatory message or badge in the UI
 - [ ] Weekly wellness summary email digest — send a weekly email with a summary of the user's logged activity and trends
 
 ### Data & Integrations

--- a/src/controllers/insights.controller.ts
+++ b/src/controllers/insights.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { getActivity, getMoodTrend, getSymptomTrend } from '../services/insights.service';
+import { getActivity, getMoodTrend, getStreak, getSymptomTrend } from '../services/insights.service';
 
 const VALID_DAYS = [7, 30, 60, 90, 120, 365];
 const MOOD_METRICS = ['mood', 'energy', 'stress'] as const;
@@ -23,6 +23,17 @@ export async function getTrends(req: Request, res: Response): Promise<void> {
       const data = await getSymptomTrend(userId, type, days);
       res.json(data);
     }
+  } catch (err) {
+    const status = (err as Error & { status?: number }).status ?? 500;
+    res.status(status).json({ error: (err as Error).message });
+  }
+}
+
+export async function getStreakSummary(req: Request, res: Response): Promise<void> {
+  const userId = req.user!.userId;
+  try {
+    const data = await getStreak(userId);
+    res.json(data);
   } catch (err) {
     const status = (err as Error & { status?: number }).status ?? 500;
     res.status(status).json({ error: (err as Error).message });

--- a/src/routes/insights.router.ts
+++ b/src/routes/insights.router.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
 import { authMiddleware } from '../middleware/auth.middleware';
-import { getActivitySummary, getTrends } from '../controllers/insights.controller';
+import { getActivitySummary, getStreakSummary, getTrends } from '../controllers/insights.controller';
 
 const router = Router();
 
 router.get('/trends', authMiddleware, getTrends);
 router.get('/activity', authMiddleware, getActivitySummary);
+router.get('/streak', authMiddleware, getStreakSummary);
 
 export default router;


### PR DESCRIPTION
## Type
Enhancement

## Summary
- Adds `GET /api/insights/streak` endpoint that computes the user's current consecutive-day logging streak across all four log types (looks back up to 400 days)
- Dashboard fetches the streak on load alongside the weekly data
- When streak first reaches 7 or 30 days, a dismissable teal banner appears below the page header (🎉 for 7-day, 🏅 for 30-day)
- Dismissed state is stored in `localStorage` keyed by `welltrack_milestone_<userId>_<N>` so each user only sees each milestone once

## Testing checklist
- [ ] Log entries for 7 consecutive days → banner appears on Dashboard
- [ ] Dismiss banner → banner is gone on next reload
- [ ] Log a second test account that hasn't reached 7 days → no banner shown
- [ ] 30-day milestone shows 🏅 badge instead of 🎉
- [ ] `GET /api/insights/streak` returns `{ currentStreak: N }` for an authenticated user