### PR TITLE
fix: improve spacing between enable/disable toggle and label in Settings

### DIFF
--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -228,12 +228,12 @@ function SymptomsSection() {
           {symptoms.map((s) => {
             const isSystem = s.userId === null;
             return (
-              <li key={s.id} className="flex items-center gap-3 py-2.5">
+              <li key={s.id} className="flex items-center gap-4 py-2.5">
                 <button
                   onClick={() => !isSystem && void handleToggle(s)}
                   disabled={isSystem}
                   title={isSystem ? 'System default — cannot be toggled' : undefined}
-                  className={`relative h-5 w-9 flex-shrink-0 rounded-full transition-colors ${
+                  className={`relative h-5 w-9 flex-shrink-0 overflow-hidden rounded-full transition-colors ${
                     s.isActive ? 'bg-teal-500' : 'bg-gray-200'
                   } ${isSystem ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'}`}
                 >
@@ -377,12 +377,12 @@ function HabitsSection() {
           {habits.map((h) => {
             const isSystem = h.userId === null;
             return (
-              <li key={h.id} className="flex items-center gap-3 py-2.5">
+              <li key={h.id} className="flex items-center gap-4 py-2.5">
                 <button
                   onClick={() => !isSystem && void handleToggle(h)}
                   disabled={isSystem}
                   title={isSystem ? 'System default — cannot be toggled' : undefined}
-                  className={`relative h-5 w-9 flex-shrink-0 rounded-full transition-colors ${
+                  className={`relative h-5 w-9 flex-shrink-0 overflow-hidden rounded-full transition-colors ${
                     h.isActive ? 'bg-teal-500' : 'bg-gray-200'
                   } ${isSystem ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'}`}
                 >
@@ -615,10 +615,10 @@ function MedicationsSection() {
                   </div>
                 </div>
               ) : (
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-4">
                   <button
                     onClick={() => void handleToggle(m)}
-                    className={`relative h-5 w-9 flex-shrink-0 cursor-pointer rounded-full transition-colors ${
+                    className={`relative h-5 w-9 flex-shrink-0 cursor-pointer overflow-hidden rounded-full transition-colors ${
                       m.isActive ? 'bg-teal-500' : 'bg-gray-200'
                     }`}
                   >


### PR DESCRIPTION
## Summary

- Increases the flex `gap` from `gap-3` (12 px) to `gap-4` (16 px) on the Symptoms, Habits, and Medications toggle rows so the pill button and adjacent label text no longer run into each other
- Adds `overflow-hidden` to all three toggle pill buttons so the knob's drop shadow is clipped within the pill boundary rather than bleeding into the text

Affects the three settings sections that use a left-aligned toggle: **Symptoms**, **Habits**, and **Medications**.

Closes #109

**Type:** Bug Fix

## Test plan

- [ ] Open Settings → Symptoms: verify each toggle has clear visual separation from its label
- [ ] Open Settings → Habits: same check
- [ ] Open Settings → Medications: same check
- [ ] Confirm no regression on the Dark mode and Weekly digest toggles (those use `justify-between` and are unaffected)
- [ ] Verify in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)