### PR TITLE
fix: resolve login failure caused by rate-limit IPv6 crash (issue #118)

### DIFF
--- a/src/middleware/rate-limit.middleware.ts
+++ b/src/middleware/rate-limit.middleware.ts
@@ -1,4 +1,4 @@
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import type { Request } from 'express';
 
 /**
@@ -11,7 +11,7 @@ import type { Request } from 'express';
 export const writeRateLimit = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   limit: 200,                // max 200 write requests per window per user
-  keyGenerator: (req: Request) => req.user?.userId ?? req.ip ?? 'unknown',
+  keyGenerator: (req: Request) => req.user?.userId ?? ipKeyGenerator(req.ip ?? ''),
   standardHeaders: 'draft-8',
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later.' },


### PR DESCRIPTION
## Type
Bug Fix

## Root cause
`express-rate-limit` v8 (installed at `8.2.1`) changed the behaviour of custom `keyGenerator` functions that reference `req.ip` directly: it now **throws a `ValidationError` (code `ERR_ERL_KEY_GEN_IPV6`) at startup**, crashing the Express process before it can bind to the port.

Because the server never started, **every** endpoint — including `POST /api/auth/login` — returned a connection-refused error, making it appear that login was broken.

## Fix
Replaced `req.ip ?? 'unknown'` in the `keyGenerator` fallback with `ipKeyGenerator(req.ip ?? '')` — the helper function provided by `express-rate-limit` v8 that normalises IPv6 addresses to a consistent subnet key.

```diff
- keyGenerator: (req: Request) => req.user?.userId ?? req.ip ?? 'unknown',
+ keyGenerator: (req: Request) => req.user?.userId ?? ipKeyGenerator(req.ip ?? ''),
```

## Testing checklist
- [x] `node -e "require('./dist/app'); console.log('OK')"` exits cleanly with no ValidationError
- [x] All 367 tests pass with no `ERR_ERL_KEY_GEN_IPV6` output
- [ ] Start `npm run dev` and confirm login works end-to-end
- [ ] Confirm rate-limiting still applies (send >200 writes in 15 min, expect 429)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)