### PR TITLE
fix: add HTTP security headers via Helmet.js (issue #120)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.0.2",
         "node-cron": "^4.2.1",
@@ -4991,6 +4992,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hono": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.0.2",
     "node-cron": "^4.2.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import path from 'path';
 import cors from 'cors';
+import helmet from 'helmet';
 import express, { Request, Response } from 'express';
 import authRouter from './routes/auth.router';
 import userRouter from './routes/user.router';
@@ -18,6 +19,19 @@ import { errorHandler } from './middleware/error.middleware';
 import { writeRateLimit } from './middleware/rate-limit.middleware';
 
 const app = express();
+
+// Security headers — must be first middleware so all responses are covered.
+// style-src allows 'unsafe-inline' because the unsubscribe handler renders an
+// HTML page with inline style= attributes; all other CSP directives use Helmet
+// defaults (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy…).
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+      'style-src': ["'self'", "'unsafe-inline'"],
+    },
+  },
+}));
 
 app.use(cors({
   origin: process.env['CLIENT_ORIGIN'] ?? 'http://localhost:5173',


### PR DESCRIPTION
## Summary

- Installs `helmet` and mounts it as the first middleware in `src/app.ts`
- Every response now includes `Strict-Transport-Security`, `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, `Content-Security-Policy`, and `Referrer-Policy`
- `style-src` includes `'unsafe-inline'` to allow the unsubscribe HTML page's inline `style=` attributes — all other CSP directives use Helmet defaults

## Type

Security Fix

## Testing

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npm test` — 367/367 tests pass
- [ ] Manual: `curl -I http://localhost:3000/health` → confirm `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security` headers present
- [ ] Manual: visit `/api/users/unsubscribe?token=<valid>` → confirm page renders correctly (inline styles not blocked)

Closes #120