### PR TITLE
fix: validate avatar URL is within expected upload path before DB write

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -64,6 +64,14 @@ export async function uploadAvatarHandler(req: Request, res: Response): Promise<
   // req.file.path is relative to cwd (e.g. "public/uploads/avatars/uuid.jpg")
   // Store the URL path portion so it is served as /uploads/avatars/uuid.jpg
   const urlPath = '/' + req.file.path.replace(/\\/g, '/');
+
+  // Defensive: ensure path is within the expected avatar directory.
+  // Guards against future multer misconfiguration.
+  if (!urlPath.startsWith('/uploads/avatars/')) {
+    res.status(500).json({ error: 'Avatar storage misconfiguration' });
+    return;
+  }
+
   const user = await updateAvatar(req.user!.userId, urlPath);
   res.status(200).json(user);
 }


### PR DESCRIPTION
## Summary

- Adds a path guard in `uploadAvatarHandler` between URL construction and the DB write
- Returns HTTP 500 (server-side config error) if the resolved path does not start with `/uploads/avatars/`
- Guards against future multer misconfiguration that could allow an arbitrary path (or `data:` URI) to be stored and rendered as `<img src>` in the sidebar and Settings page

**Type:** Bug Fix / Security Fix

Closes #122

## Test plan

- [ ] Upload a valid image → confirm returned `avatarUrl` starts with `/uploads/avatars/`
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)