### PR TITLE
fix: add MIME type filter to CSV import endpoint

### DIFF
--- a/src/routes/import.router.ts
+++ b/src/routes/import.router.ts
@@ -5,11 +5,32 @@ import { importCsvHandler } from '../controllers/import.controller';
 
 const router = Router();
 
+// text/plain and application/vnd.ms-excel are included because Windows
+// browsers and curl commonly send these MIME types for .csv files.
+const ALLOWED_CSV_MIME = new Set(['text/csv', 'text/plain', 'application/vnd.ms-excel']);
+
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_CSV_MIME.has(file.mimetype)) cb(null, true);
+    else cb(new Error('Only CSV files are accepted'));
+  },
 });
 
-router.post('/csv', authMiddleware, upload.single('file'), importCsvHandler);
+router.post(
+  '/csv',
+  authMiddleware,
+  (req, res, next) => {
+    upload.single('file')(req, res, (err) => {
+      if (err instanceof multer.MulterError || err instanceof Error) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      next();
+    });
+  },
+  importCsvHandler,
+);
 
 export default router;


### PR DESCRIPTION
## Summary

- Adds a `fileFilter` to the multer instance on `POST /api/import/csv` accepting only `text/csv`, `text/plain`, and `application/vnd.ms-excel` (the three MIME types browsers and curl commonly send for `.csv` files)
- Any other MIME type returns **HTTP 400** with `{ error: 'Only CSV files are accepted' }`
- The route handler is wrapped so multer errors surface as `400` JSON rather than propagating as an unhandled `500`

**Type:** Bug Fix / Security Fix

Closes #123

## Test plan

- [ ] Submit a JPEG to `POST /api/import/csv` → HTTP 400 `{ "error": "Only CSV files are accepted" }`
- [ ] Submit a valid CSV with `Content-Type: text/plain` → HTTP 200
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)