### PR TITLE
fix: explicitly disable source maps in production Vite build

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     tailwindcss(),
   ],
   build: {
+    sourcemap: false, // explicit: prevent accidental exposure of source code in production
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Summary

- Adds `sourcemap: false` as the first property in the `build` block of `client/vite.config.ts`
- This was already the effective default, but making it explicit prevents a developer from accidentally enabling source maps during debugging and forgetting to revert before deploying, which would expose the full TypeScript/React source via DevTools

**Type:** Enhancement / Hardening

Closes #125

## Test plan

- [ ] `cd client && npm run build`
- [ ] Confirm no `.map` files appear in `dist/assets/`
- [ ] Bundle sizes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)