### PR TITLE
fix: exempt /refresh and /logout from auth rate limit; skip GET in writeRateLimit (issue #135)

### DIFF
--- a/src/middleware/rate-limit.middleware.ts
+++ b/src/middleware/rate-limit.middleware.ts
@@ -7,6 +7,11 @@ import type { Request } from 'express';
  * Falls back to IP for unauthenticated requests that reach protected routes
  * (auth middleware will reject them before the handler runs, but we still
  * want to limit brute-force attempts at those routes).
+ *
+ * GET requests are skipped — reads are not a brute-force risk and the
+ * keyGenerator falls back to IP (req.user is not yet populated when this
+ * middleware runs), which would bucket all reads from the same host together
+ * and prematurely rate-limit normal browsing.
  */
 export const writeRateLimit = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
@@ -15,6 +20,7 @@ export const writeRateLimit = rateLimit({
   standardHeaders: 'draft-8',
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later.' },
+  skip: (req: Request) => req.method === 'GET' || process.env['NODE_ENV'] === 'test',
 });
 
 /**
@@ -24,8 +30,14 @@ export const writeRateLimit = rateLimit({
  * (a user mistyping their password a few times) while blocking credential
  * stuffing and brute-force attacks.
  *
- * Skipped in the test environment so auth integration tests — which make
- * many sequential requests — do not start returning 429s mid-suite.
+ * /refresh and /logout are excluded: the client calls them automatically on
+ * every page load (to restore the in-memory access token) and on logout.
+ * Subjecting those machine-driven calls to the 5-request limit causes the
+ * refresh to return 429, which clears the stored tokens and logs the user
+ * out — making all their data appear missing.
+ *
+ * Skipped entirely in the test environment so auth integration tests —
+ * which make many sequential requests — do not start returning 429s mid-suite.
  */
 export const authRateLimit = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -34,5 +46,8 @@ export const authRateLimit = rateLimit({
   standardHeaders: 'draft-8',
   legacyHeaders: false,
   message: { error: 'Too many authentication attempts, please try again later.' },
-  skip: () => process.env['NODE_ENV'] === 'test',
+  skip: (req: Request) =>
+    process.env['NODE_ENV'] === 'test' ||
+    req.path === '/refresh' ||
+    req.path === '/logout',
 });


### PR DESCRIPTION
## Type
Bug Fix

## Summary
- **`authRateLimit`** (limit: 5/15 min) was being applied to `POST /api/auth/refresh` and `POST /api/auth/logout`. The frontend calls `/refresh` on every page load to restore the in-memory access token from `localStorage`. After 5 page loads the 6th `/refresh` returned 429; `AuthContext` caught it, cleared tokens, and silently logged the user out — all subsequent API calls failed with 401 and the dashboard `.catch()` zeroed every count.
- **`writeRateLimit`** was applied to all HTTP methods including GET. Because `req.user` is not populated when the middleware runs (auth middleware is inside each router), the key always fell back to `ipKeyGenerator(req.ip)`, bucking all reads from the same host into a shared 200-request pool.

## Changes
- `src/middleware/rate-limit.middleware.ts`: add `skip` to `authRateLimit` to exclude `/refresh` and `/logout`; add `skip` to `writeRateLimit` to exclude GET requests and test runs.

## Test plan
- [ ] `npx jest auth.login auth.refresh auth.logout auth.register` — all 33 auth tests pass
- [ ] Start the app, log in, reload the page 6+ times — session should stay alive and all data should remain visible
- [ ] Verify write endpoints (POST symptom-log, etc.) are still subject to the write rate limit
- [ ] Verify login/register/forgot-password are still subject to the 5-request auth rate limit

Fixes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)