### PR TITLE
fix: reduce idle logout timeout from 30 minutes to 5 minutes (issue #134)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -5,7 +5,7 @@ import { useIdleLogout } from '../hooks/useIdleLogout';
 import api from '../services/api';
 import type { UserProfile } from '../types/api';
 
-const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 const navLinks = [
   { to: '/', label: 'Dashboard', end: true },


### PR DESCRIPTION
## Type
Bug Fix

## Summary
- Changes `IDLE_TIMEOUT_MS` in `AppLayout.tsx` from `30 * 60 * 1000` (30 min) to `5 * 60 * 1000` (5 min).
- No other behaviour changes — the hook, events, and login-page banner are unchanged.

> **Note:** This PR stacks on `fix/128-idle-logout` which introduced the idle-logout feature. It should be merged after that branch is merged to `main`.

## Test plan
- [ ] Log in to the app, stay idle for 5 minutes — should be redirected to `/login` with the inactivity banner
- [ ] Confirm activity (mouse move / keydown) resets the timer

Fixes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)